### PR TITLE
Run tests in parallel

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestBlock_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Directives []IDirective
 	}
@@ -113,6 +114,7 @@ func NewServerOrNill(directive IDirective) *Server {
 }
 
 func TestBlock_FindDirectives(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		directiveName string
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestConfig_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Block    *Block
 		FilePath string

--- a/directive_test.go
+++ b/directive_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestDirective_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Name       string
 		Parameters []string
@@ -71,6 +72,7 @@ func TestDirective_ToString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			d := &Directive{
 				Name:       tt.fields.Name,
 				Parameters: tt.fields.Parameters,

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestStyle_Iterate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		style *Style

--- a/http_test.go
+++ b/http_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestHttp_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Directive *Directive
 	}

--- a/include_test.go
+++ b/include_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig_IncludeToString(t *testing.T) {
-
+	t.Parallel()
 	include := &Include{
 		Directive: &Directive{
 			Name:       "include",

--- a/location_test.go
+++ b/location_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestLocation_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Directive *Directive
 		Modifier  string

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestScanner_Lex(t *testing.T) {
+	t.Parallel()
 	actual := lex(`
 server { # simple reverse-proxy
     listen       80;
@@ -101,6 +102,7 @@ func panicFunc() {
 }
 
 func TestScanner_LexPanicUnclosedQuote(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParser_CurrFollow(t *testing.T) {
+	t.Parallel()
 	conf := `
 	server { # simple reverse-proxy
 	}
@@ -31,6 +32,7 @@ func TestParser_CurrFollow(t *testing.T) {
 //}
 
 func TestParser_UnendedInclude(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")
@@ -45,6 +47,7 @@ func TestParser_UnendedInclude(t *testing.T) {
 }
 
 func TestParser_LocationNoParam(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")
@@ -59,6 +62,7 @@ func TestParser_LocationNoParam(t *testing.T) {
 }
 
 func TestParser_LocationTooManyParam(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")
@@ -73,6 +77,7 @@ func TestParser_LocationTooManyParam(t *testing.T) {
 }
 
 func TestParser_ParseValidLocations(t *testing.T) {
+	t.Parallel()
 	NewParserFromLexer(
 		lex(`
 	server { 
@@ -88,6 +93,7 @@ func TestParser_ParseValidLocations(t *testing.T) {
 }
 
 func TestParser_ParseUpstream(t *testing.T) {
+	t.Parallel()
 	NewParserFromLexer(
 		lex(`
 		upstream my_upstream{
@@ -107,6 +113,7 @@ func TestParser_ParseUpstream(t *testing.T) {
 }
 
 func TestParser_ParseFromFile(t *testing.T) {
+	t.Parallel()
 	_, err := NewParser("../full-example/nginx.conf")
 	assert.NilError(t, err)
 	_, err2 := NewParser("../full-example/nginx.conf-not-found")
@@ -114,6 +121,7 @@ func TestParser_ParseFromFile(t *testing.T) {
 }
 
 func TestParser_MultiParamDirecive(t *testing.T) {
+	t.Parallel()
 	NewParserFromLexer(
 		lex(`
 http{
@@ -128,6 +136,7 @@ http{
 }
 
 func TestParser_Location(t *testing.T) {
+	t.Parallel()
 	c := NewParserFromLexer(
 		lex(`
 		location ~ /and/ends{
@@ -140,6 +149,7 @@ func TestParser_Location(t *testing.T) {
 }
 
 func TestParser_VariableAsParameter(t *testing.T) {
+	t.Parallel()
 	c := NewParserFromLexer(
 		lex(`
 			map $host $clientname {
@@ -156,6 +166,7 @@ func TestParser_VariableAsParameter(t *testing.T) {
 }
 
 func TestParser_UnendedMultiParams(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")
@@ -170,6 +181,7 @@ func TestParser_UnendedMultiParams(t *testing.T) {
 }
 
 func TestParser_SkipComment(t *testing.T) {
+	t.Parallel()
 	NewParserFromLexer(lex(`
 if ($a ~* "")#comment
 #comment
@@ -180,6 +192,7 @@ return 400;
 }
 
 func TestParser_Include(t *testing.T) {
+	t.Parallel()
 	p, err := NewParser("../testdata/include-glob/nginx.conf", WithIncludeParsing())
 	if err != nil {
 		t.Fatal(err)

--- a/parser/token/token_test.go
+++ b/parser/token/token_test.go
@@ -30,6 +30,7 @@ func TestType_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := tt.tt.String(); got != tt.want {
 				t.Errorf("Type.String() = %v, want %v", got, tt.want)
 			}
@@ -62,6 +63,7 @@ func TestToken_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tok := Token{
 				Type:    tt.fields.Type,
 				Literal: tt.fields.Literal,
@@ -112,6 +114,7 @@ func TestToken_Lit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tok := Token{
 				Type:    tt.fields.Type,
 				Literal: tt.fields.Literal,

--- a/server_test.go
+++ b/server_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestServer_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Directive *Directive
 	}

--- a/upstream_server_test.go
+++ b/upstream_server_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestNewUpstreamServer(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		directive *Directive
 	}

--- a/upstream_test.go
+++ b/upstream_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestUpstream_ToString(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Directive *Directive
 		Name      string
@@ -105,6 +106,7 @@ func TestUpstream_ToString(t *testing.T) {
 }
 
 func TestUpstream_AddServer(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		UpstreamName    string
 		UpstreamServers []*UpstreamServer


### PR DESCRIPTION
Hi @tufanbarisyildirim, this PR proposes changes to test files to allow parallel test execution.

Testing locally:
```
➜  gonginx git:(paralleltests) ✗ go test -race ./... -count=1
ok  	github.com/tufanbarisyildirim/gonginx	0.217s
?   	github.com/tufanbarisyildirim/gonginx/examples/adding-server	[no test files]
?   	github.com/tufanbarisyildirim/gonginx/examples/formatting	[no test files]
?   	github.com/tufanbarisyildirim/gonginx/examples/update-directive	[no test files]
ok  	github.com/tufanbarisyildirim/gonginx/parser	0.335s
ok  	github.com/tufanbarisyildirim/gonginx/parser/token	0.160s
```
Testing locally using make target:
```
➜  gonginx git:(paralleltests) make test
go test -race -cover /Users/jakub/projects/gonginx/parser/token
ok  	github.com/tufanbarisyildirim/gonginx/parser/token	(cached)	coverage: 100.0% of statements
go test -race -cover /Users/jakub/projects/gonginx/parser
ok  	github.com/tufanbarisyildirim/gonginx/parser	(cached)	coverage: 95.3% of statements
go test -race -cover /Users/jakub/projects/gonginx
ok  	github.com/tufanbarisyildirim/gonginx	(cached)	coverage: 65.7% of statements
```
