### PR TITLE
Make Go linter happy

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.14
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: latest
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,43 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.29
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ test:
 	go test -race -cover ${PWD}/parser
 	go test -race -cover ${PWD}
 
+lint:
+	golangci-lint run ./...
+
 example:
 	go run ${PWD}/examples/$(example)
 
@@ -18,4 +21,4 @@ fmt:
 deps:
 	go get -v all
 
-.PHONY: fmt deps test
+.PHONY: fmt deps test lint

--- a/dumper.go
+++ b/dumper.go
@@ -108,8 +108,7 @@ func DumpBlock(b IBlock, style *Style) string {
 			buf.WriteString("\n")
 		}
 	}
-
-	return string(buf.Bytes())
+	return buf.String()
 }
 
 //DumpConfig dump whole config

--- a/http.go
+++ b/http.go
@@ -43,9 +43,7 @@ func (h *Http) GetParameters() []string {
 //GetDirectives get all directives in http
 func (h *Http) GetDirectives() []IDirective {
 	directives := make([]IDirective, 0)
-	for _, directive := range h.Directives {
-		directives = append(directives, directive)
-	}
+	directives = append(directives, h.Directives...)
 	for _, directive := range h.Servers {
 		directives = append(directives, directive)
 	}

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -97,10 +97,6 @@ directive "with a quoted string\t \r\n \\ with some escaped thing s\" good.";
 	assert.Equal(t, len(actual), len(expect))
 }
 
-func panicFunc() {
-
-}
-
 func TestScanner_LexPanicUnclosedQuote(t *testing.T) {
 	t.Parallel()
 	defer func() {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -162,7 +162,7 @@ parsingloop:
 			break parsingloop
 		case p.curTokenIs(token.Keyword):
 			context.Directives = append(context.Directives, p.parseStatement())
-			break
+			break parsingloop
 		}
 		p.nextToken()
 	}

--- a/upstream_server.go
+++ b/upstream_server.go
@@ -55,9 +55,7 @@ func (uss *UpstreamServer) GetDirective() *Directive {
 	}
 
 	//append flags to the end of the directive.
-	for _, flag := range uss.Flags {
-		directive.Parameters = append(directive.Parameters, flag)
-	}
+	directive.Parameters = append(directive.Parameters, uss.Flags...)
 
 	return directive
 }


### PR DESCRIPTION
Hi @tufanbarisyildirim, if you don't mind this PR introduces additional quality checks using [Go linter](https://golangci-lint.run/usage/quick-start). I have run Go linter locally on my laptop and this PR includes suggested fixes.

Executing Go linter before the change:
```
➜  gonginx git:(linterfix) golangci-lint run ./...

parser/lexer_test.go:100:6: `panicFunc` is unused (deadcode)
func panicFunc() {
     ^
parser/parser.go:165:4: S1023: redundant break statement (gosimple)
			break
			^
dumper.go:112:9: S1030: should use buf.String() instead of string(buf.Bytes()) (gosimple)
	return string(buf.Bytes())
	       ^
http.go:46:2: S1011: should replace loop with `directives = append(directives, h.Directives...)` (gosimple)
	for _, directive := range h.Directives {
	^
upstream_server.go:58:2: S1011: should replace loop with `directive.Parameters = append(directive.Parameters, uss.Flags...)` (gosimple)
	for _, flag := range uss.Flags {
	^
```
After changes applied:
```
➜  gonginx git:(linterfix) golangci-lint run ./...
```
Also, if you are ok with it I am including a separate [github action](https://github.com/marketplace/actions/run-golangci-lint) to run linter automatically on PRs.

