### PR TITLE
fix: parseBlock stopped after first directive

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -162,7 +162,6 @@ parsingloop:
 			break parsingloop
 		case p.curTokenIs(token.Keyword):
 			context.Directives = append(context.Directives, p.parseStatement())
-			break parsingloop
 		}
 		p.nextToken()
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -198,7 +198,13 @@ func TestParser_Include(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.Parse()
+	c := p.Parse()
+	s := gonginx.DumpConfig(c, gonginx.IndentedStyle)
+
+	assert.Equal(t, `user www www;
+worker_processes 5;
+include events.conf;
+include http.conf;`, s)
 }
 
 func Benchmark_ParseFullExample(t *testing.B) {


### PR DESCRIPTION
Parser shouldn't break out of `parsingLoop` when the current token is a keyword.