### PR TITLE
feat: associate comments with config objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 # VSCode
 .vscode/
 
+# GoLand
+.idea
+

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ keyword     : Keyword
 
 
 #### TODO
-- [ ]  associate comments with config objects to print them on config generation and make it configurable with `dumper.Style`
+- [x]  associate comments with config objects to print them on config generation and make it configurable with `dumper.Style`
 - [ ]  move any context wrapper into their own file (remove from parser)
 - [ ]  Parse included files recusively, keep relative path on load, save all in a related structure and make that optional in dumper.Style
 - [ ]  Implement specific searches, like finding servers by server_name (domain) or any upstream by target etc.

--- a/directive.go
+++ b/directive.go
@@ -1,23 +1,33 @@
 package gonginx
 
-//Directive represents any nginx directive
+// Directive represents any nginx directive
 type Directive struct {
 	Block      IBlock
 	Name       string
 	Parameters []string //TODO: Save parameters with their type
+	Comment    []string
 }
 
-//GetName get directive name
+func (d *Directive) SetComment(comment []string) {
+	d.Comment = comment
+}
+
+// GetName get directive name
 func (d *Directive) GetName() string {
 	return d.Name
 }
 
-//GetParameters get all parameters of a directive
+// GetParameters get all parameters of a directive
 func (d *Directive) GetParameters() []string {
 	return d.Parameters
 }
 
-//GetBlock get block if it has
+// GetBlock get block if it has
 func (d *Directive) GetBlock() IBlock {
 	return d.Block
+}
+
+// GetComment get directive comment
+func (d *Directive) GetComment() []string {
+	return d.Comment
 }

--- a/directive_test.go
+++ b/directive_test.go
@@ -69,6 +69,16 @@ func TestDirective_ToString(t *testing.T) {
 			},
 			want: "charset koi8-r;",
 		},
+		{
+			name: "'' close",
+			fields: fields{
+				Name: "''",
+				Parameters: []string{
+					"close",
+				},
+			},
+			want: "'' close;",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dumper.go
+++ b/dumper.go
@@ -41,7 +41,7 @@ var (
 	}
 )
 
-//Style dumping style
+// Style dumping style
 type Style struct {
 	SortDirectives    bool
 	SpaceBeforeBlocks bool
@@ -49,7 +49,7 @@ type Style struct {
 	Indent            int
 }
 
-//NewStyle create new style
+// NewStyle create new style
 func NewStyle() *Style {
 	style := &Style{
 		SortDirectives: false,
@@ -59,7 +59,7 @@ func NewStyle() *Style {
 	return style
 }
 
-//Iterate interate the indentation for sub blocks
+// Iterate interate the indentation for sub blocks
 func (s *Style) Iterate() *Style {
 	newStyle := &Style{
 		SortDirectives:    s.SortDirectives,
@@ -70,12 +70,17 @@ func (s *Style) Iterate() *Style {
 	return newStyle
 }
 
-//DumpDirective convert a directive to a string
+// DumpDirective convert a directive to a string
 func DumpDirective(d IDirective, style *Style) string {
 	var buf bytes.Buffer
 
 	if style.SpaceBeforeBlocks && d.GetBlock() != nil {
 		buf.WriteString("\n")
+	}
+	if len(d.GetComment()) > 0 {
+		for _, comment := range d.GetComment() {
+			buf.WriteString(fmt.Sprintf("%s%s\n", strings.Repeat(" ", style.StartIndent), comment))
+		}
 	}
 	buf.WriteString(fmt.Sprintf("%s%s", strings.Repeat(" ", style.StartIndent), d.GetName()))
 	if len(d.GetParameters()) > 0 {
@@ -91,7 +96,7 @@ func DumpDirective(d IDirective, style *Style) string {
 	return buf.String()
 }
 
-//DumpBlock convert a directive to a string
+// DumpBlock convert a directive to a string
 func DumpBlock(b IBlock, style *Style) string {
 	var buf bytes.Buffer
 
@@ -111,7 +116,7 @@ func DumpBlock(b IBlock, style *Style) string {
 	return buf.String()
 }
 
-//DumpConfig dump whole config
+// DumpConfig dump whole config
 func DumpConfig(c *Config, style *Style) string {
 	return DumpBlock(c.Block, style)
 }

--- a/examples/formatting/main.go
+++ b/examples/formatting/main.go
@@ -37,6 +37,11 @@ root html;
 # comment: location
 location ~ \.php$ {
 fastcgi_pass 127.0.0.1:1025; } } 
+map $http_upgrade $connection_upgrade {
+	default upgrade;
+	'' close;
+	test '';
+}
 # comment: server
 server {
 listen 80;

--- a/examples/formatting/main.go
+++ b/examples/formatting/main.go
@@ -13,7 +13,10 @@ worker_processes 5;
 error_log logs/error.log;
 pid logs/nginx.pid;
 worker_rlimit_nofile 8192;
-events { worker_connections 4096; } http {
+events { worker_connections 4096; } 
+# http comment
+http {
+# include comment
 include mime.types;
 include proxy.conf;
 include fastcgi.conf;
@@ -31,8 +34,11 @@ listen 80;
 server_name domain1.com www.domain1.com;
 access_log logs/domain1.access.log main;
 root html;
+# comment: location
 location ~ \.php$ {
-fastcgi_pass 127.0.0.1:1025; } } server {
+fastcgi_pass 127.0.0.1:1025; } } 
+# comment: server
+server {
 listen 80;
 server_name domain2.com www.domain2.com;
 access_log logs/domain2.access.log main;
@@ -40,13 +46,19 @@ location ~ ^/(images|javascript|js|css|flash|media|static)/ {
 root /var/www/virtual/big.server.com/htdocs;
 expires 30d;
 } location / { proxy_pass http://127.0.0.1:8080; } }
+# comment: big_server_com
+# comment: upstream big_server_com
 upstream big_server_com {
-server 127.0.0.3:8000 weight=5;
-server 127.0.0.3:8001 weight=5;
+server 127.0.0.3:8000 weight=5; # inline comment: server 127.0.0.3:8000 weight=5
+server 127.0.0.3:8001 weight=5; # inline comment: server 127.0.0.3:8000 weight=5
 server 192.168.0.1:8000;
 server 192.168.0.1:8001;
-} server { listen 80;
+}
+# comment: server
+server { # comment: listen
+listen 80;
 server_name big.server.com;
+# comment: access_log
 access_log logs/big.server.access.log main;
 location / { proxy_pass http://big_server_com; } } }`)
 

--- a/http.go
+++ b/http.go
@@ -4,13 +4,22 @@ import (
 	"errors"
 )
 
-//Http represents http block
+// Http represents http block
 type Http struct {
 	Servers    []*Server
 	Directives []IDirective
+	Comment    []string
 }
 
-//NewHttp create an http block from a directive which has a block
+func (h *Http) GetComment() []string {
+	return h.Comment
+}
+
+func (h *Http) SetComment(comment []string) {
+	h.Comment = comment
+}
+
+// NewHttp create an http block from a directive which has a block
 func NewHttp(directive IDirective) (*Http, error) {
 	if block := directive.GetBlock(); block != nil {
 		http := &Http{
@@ -24,23 +33,24 @@ func NewHttp(directive IDirective) (*Http, error) {
 			}
 			http.Directives = append(http.Directives, directive)
 		}
+		http.Comment = directive.GetComment()
 
 		return http, nil
 	}
 	return nil, errors.New("http directive must have a block")
 }
 
-//GetName get directive name to construct the statment string
+// GetName get directive name to construct the statment string
 func (h *Http) GetName() string { //the directive name.
 	return "http"
 }
 
-//GetParameters get directive parameters if any
+// GetParameters get directive parameters if any
 func (h *Http) GetParameters() []string {
 	return []string{}
 }
 
-//GetDirectives get all directives in http
+// GetDirectives get all directives in http
 func (h *Http) GetDirectives() []IDirective {
 	directives := make([]IDirective, 0)
 	directives = append(directives, h.Directives...)
@@ -50,7 +60,7 @@ func (h *Http) GetDirectives() []IDirective {
 	return directives
 }
 
-//FindDirectives find directives
+// FindDirectives find directives
 func (h *Http) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range h.GetDirectives() {
@@ -70,7 +80,7 @@ func (h *Http) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
-//GetBlock get block if any
+// GetBlock get block if any
 func (h *Http) GetBlock() IBlock {
 	return h
 }

--- a/include.go
+++ b/include.go
@@ -1,6 +1,6 @@
 package gonginx
 
-//Include include structure
+// Include include structure
 type Include struct {
 	*Directive
 	IncludePath string
@@ -40,7 +40,11 @@ func (c *Include) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
-//GetName get directive name
-func (i *Include) GetName() string {
-	return i.Directive.Name
+// GetName get directive name
+func (c *Include) GetName() string {
+	return c.Directive.Name
+}
+
+func (c *Include) SetComment(comment []string) {
+	c.Comment = comment
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,11 +3,10 @@ package parser
 import (
 	"bufio"
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/tufanbarisyildirim/gonginx"
 	"github.com/tufanbarisyildirim/gonginx/parser/token"
+	"os"
+	"path/filepath"
 )
 
 type Option func(*Parser)
@@ -17,7 +16,7 @@ type options struct {
 	skipIncludeParsingErr bool
 }
 
-//Parser is an nginx config parser
+// Parser is an nginx config parser
 type Parser struct {
 	opts              options
 	configRoot        string // TODO: confirmation needed (whether this is the parent of nginx.conf)
@@ -28,6 +27,7 @@ type Parser struct {
 	statementParsers  map[string]func() gonginx.IDirective
 	blockWrappers     map[string]func(*gonginx.Directive) gonginx.IDirective
 	directiveWrappers map[string]func(*gonginx.Directive) gonginx.IDirective
+	commentBuffer     []string
 }
 
 func WithSameOptions(p *Parser) Option {
@@ -66,12 +66,12 @@ func WithIncludeParsing() Option {
 	}
 }
 
-//NewStringParser parses nginx conf from string
+// NewStringParser parses nginx conf from string
 func NewStringParser(str string, opts ...Option) *Parser {
 	return NewParserFromLexer(lex(str), opts...)
 }
 
-//NewParser create new parser
+// NewParser create new parser
 func NewParser(filePath string, opts ...Option) (*Parser, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -83,7 +83,7 @@ func NewParser(filePath string, opts ...Option) (*Parser, error) {
 	return p, nil
 }
 
-//NewParserFromLexer initilizes a new Parser
+// NewParserFromLexer initilizes a new Parser
 func NewParserFromLexer(lexer *lexer, opts ...Option) *Parser {
 	configRoot, _ := filepath.Split(lexer.file)
 	parser := &Parser{
@@ -140,7 +140,7 @@ func (p *Parser) followingTokenIs(t token.Type) bool {
 	return p.followingToken.Type == t
 }
 
-//Parse the gonginx.
+// Parse the gonginx.
 func (p *Parser) Parse() *gonginx.Config {
 	return &gonginx.Config{
 		FilePath: p.lexer.file, //TODO: set filepath here,
@@ -148,20 +148,30 @@ func (p *Parser) Parse() *gonginx.Config {
 	}
 }
 
-//ParseBlock parse a block statement
+// ParseBlock parse a block statement
 func (p *Parser) parseBlock() *gonginx.Block {
 
 	context := &gonginx.Block{
 		Directives: make([]gonginx.IDirective, 0),
 	}
-
+	var s gonginx.IDirective
+	var line int
 parsingloop:
 	for {
 		switch {
 		case p.curTokenIs(token.EOF) || p.curTokenIs(token.BlockEnd):
 			break parsingloop
 		case p.curTokenIs(token.Keyword):
-			context.Directives = append(context.Directives, p.parseStatement())
+			s = p.parseStatement()
+			context.Directives = append(context.Directives, s)
+			line = p.currentToken.Line
+		case p.curTokenIs(token.Comment):
+			p.commentBuffer = append(p.commentBuffer, p.currentToken.Literal)
+			// inline comment
+			if line == p.currentToken.Line {
+				s.SetComment(p.commentBuffer)
+				p.commentBuffer = nil
+			}
 		}
 		p.nextToken()
 	}
@@ -179,6 +189,11 @@ func (p *Parser) parseStatement() gonginx.IDirective {
 		return sp()
 	}
 
+	if len(p.commentBuffer) > 0 {
+		d.Comment = p.commentBuffer
+		p.commentBuffer = nil
+	}
+
 	//parse parameters until the end.
 	for p.nextToken(); p.currentToken.IsParameterEligible(); p.nextToken() {
 		d.Parameters = append(d.Parameters, p.currentToken.Literal)
@@ -191,9 +206,9 @@ func (p *Parser) parseStatement() gonginx.IDirective {
 		}
 		return d
 	}
-
 	for {
 		if p.curTokenIs(token.Comment) {
+			p.commentBuffer = append(p.commentBuffer, p.currentToken.Literal)
 			p.nextToken()
 		} else {
 			break
@@ -212,7 +227,7 @@ func (p *Parser) parseStatement() gonginx.IDirective {
 	panic(fmt.Errorf("unexpected token %s (%s) on line %d, column %d", p.currentToken.Type.String(), p.currentToken.Literal, p.currentToken.Line, p.currentToken.Column))
 }
 
-//TODO: move this into gonginx.Include
+// TODO: move this into gonginx.Include
 func (p *Parser) parseInclude(directive *gonginx.Directive) *gonginx.Include {
 	include := &gonginx.Include{
 		Directive:   directive,
@@ -265,7 +280,7 @@ func (p *Parser) parseInclude(directive *gonginx.Directive) *gonginx.Include {
 	return include
 }
 
-//TODO: move this into gonginx.Location
+// TODO: move this into gonginx.Location
 func (p *Parser) wrapLocation(directive *gonginx.Directive) *gonginx.Location {
 	location := &gonginx.Location{
 		Modifier:  "",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -161,7 +161,7 @@ parsingloop:
 		switch {
 		case p.curTokenIs(token.EOF) || p.curTokenIs(token.BlockEnd):
 			break parsingloop
-		case p.curTokenIs(token.Keyword):
+		case p.curTokenIs(token.Keyword) || p.curTokenIs(token.QuotedString):
 			s = p.parseStatement()
 			context.Directives = append(context.Directives, s)
 			line = p.currentToken.Line

--- a/server.go
+++ b/server.go
@@ -4,33 +4,42 @@ import (
 	"errors"
 )
 
-//Server represents server block
+// Server represents server block
 type Server struct {
-	Block IBlock
+	Block   IBlock
+	Comment []string
 }
 
-//NewServer create a server block from a directive with block
+func (s *Server) SetComment(comment []string) {
+	s.Comment = comment
+}
+
+func (s *Server) GetComment() []string {
+	return s.Comment
+}
+
+// NewServer create a server block from a directive with block
 func NewServer(directive IDirective) (*Server, error) {
 	if block := directive.GetBlock(); block != nil {
 		return &Server{
-			Block: block,
+			Block:   block,
+			Comment: directive.GetComment(),
 		}, nil
 	}
-
 	return nil, errors.New("server directive must have a block")
 }
 
-//GetName get directive name to construct the statment string
+// GetName get directive name to construct the statment string
 func (s *Server) GetName() string { //the directive name.
 	return "server"
 }
 
-//GetParameters get directive parameters if any
+// GetParameters get directive parameters if any
 func (s *Server) GetParameters() []string {
 	return []string{}
 }
 
-//GetBlock get block if any
+// GetBlock get block if any
 func (s *Server) GetBlock() IBlock {
 	return s.Block
 }

--- a/statement.go
+++ b/statement.go
@@ -1,24 +1,26 @@
 package gonginx
 
-//IBlock represents any directive block
+// IBlock represents any directive block
 type IBlock interface {
 	GetDirectives() []IDirective
 	FindDirectives(directiveName string) []IDirective
 }
 
-//IDirective represents any directive
+// IDirective represents any directive
 type IDirective interface {
 	GetName() string //the directive name.
 	GetParameters() []string
 	GetBlock() IBlock
+	GetComment() []string
+	SetComment(comment []string)
 }
 
-//FileDirective a statement that saves its own file
+// FileDirective a statement that saves its own file
 type FileDirective interface {
 	isFileDirective()
 }
 
-//IncludeDirective represents include statement in nginx
+// IncludeDirective represents include statement in nginx
 type IncludeDirective interface {
 	FileDirective
 }

--- a/upstream.go
+++ b/upstream.go
@@ -4,30 +4,40 @@ import (
 	"errors"
 )
 
-//Upstream represents `upstream{}` block
+// Upstream represents `upstream{}` block
 type Upstream struct {
 	UpstreamName    string
 	UpstreamServers []*UpstreamServer
 	//Directives Other directives in upstream (ip_hash; etc)
 	Directives []IDirective
+	Comment    []string
 }
 
-//GetName Statement interface
+func (us *Upstream) SetComment(comment []string) {
+	us.Comment = comment
+}
+
+// GetName Statement interface
 func (us *Upstream) GetName() string {
 	return "upstream"
 }
 
-//GetParameters upsrema parameters
+// GetParameters upsrema parameters
 func (us *Upstream) GetParameters() []string {
 	return []string{us.UpstreamName} //the only parameter for an upstream is its name
 }
 
-//GetBlock upstream does not have block
+// GetBlock upstream does not have block
 func (us *Upstream) GetBlock() IBlock {
 	return us
 }
 
-//GetDirectives get sub directives of upstream
+// GetComment get directive comment
+func (us *Upstream) GetComment() []string {
+	return us.Comment
+}
+
+// GetDirectives get sub directives of upstream
 func (us *Upstream) GetDirectives() []IDirective {
 	directives := make([]IDirective, 0)
 	directives = append(directives, us.Directives...)
@@ -38,7 +48,7 @@ func (us *Upstream) GetDirectives() []IDirective {
 	return directives
 }
 
-//NewUpstream creaste new upstream from a directive
+// NewUpstream creaste new upstream from a directive
 func NewUpstream(directive IDirective) (*Upstream, error) {
 	parameters := directive.GetParameters()
 	us := &Upstream{
@@ -59,15 +69,17 @@ func NewUpstream(directive IDirective) (*Upstream, error) {
 		}
 	}
 
+	us.Comment = directive.GetComment()
+
 	return us, nil
 }
 
-//AddServer add a server to upstream
+// AddServer add a server to upstream
 func (us *Upstream) AddServer(server *UpstreamServer) {
 	us.UpstreamServers = append(us.UpstreamServers, server)
 }
 
-//FindDirectives find directives in block recursively
+// FindDirectives find directives in block recursively
 func (us *Upstream) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range us.Directives {

--- a/upstream_server.go
+++ b/upstream_server.go
@@ -6,29 +6,38 @@ import (
 	"strings"
 )
 
-//UpstreamServer represents `server` directive in `upstream{}` block
+// UpstreamServer represents `server` directive in `upstream{}` block
 type UpstreamServer struct {
 	Address    string
 	Flags      []string
 	Parameters map[string]string
+	Comment    []string
 }
 
-//GetName return directive name, Statement  interface
+func (uss *UpstreamServer) SetComment(comment []string) {
+	uss.Comment = comment
+}
+
+func (uss *UpstreamServer) GetComment() []string {
+	return uss.Comment
+}
+
+// GetName return directive name, Statement  interface
 func (uss *UpstreamServer) GetName() string {
 	return "server"
 }
 
-//GetBlock block of an upstream, basically nil
+// GetBlock block of an upstream, basically nil
 func (uss *UpstreamServer) GetBlock() IBlock {
 	return nil
 }
 
-//GetParameters block of an upstream, basically nil
+// GetParameters block of an upstream, basically nil
 func (uss *UpstreamServer) GetParameters() []string {
 	return uss.GetDirective().Parameters
 }
 
-//GetDirective get directive of the upstreamserver
+// GetDirective get directive of the upstreamserver
 func (uss *UpstreamServer) GetDirective() *Directive {
 	//First, generate a new directive from upstream server
 	directive := &Directive{
@@ -57,14 +66,17 @@ func (uss *UpstreamServer) GetDirective() *Directive {
 	//append flags to the end of the directive.
 	directive.Parameters = append(directive.Parameters, uss.Flags...)
 
+	directive.Comment = uss.GetComment()
+
 	return directive
 }
 
-//NewUpstreamServer creates an upstream server from a directive
+// NewUpstreamServer creates an upstream server from a directive
 func NewUpstreamServer(directive IDirective) *UpstreamServer {
 	uss := &UpstreamServer{
 		Flags:      make([]string, 0),
 		Parameters: make(map[string]string, 0),
+		Comment:    make([]string, 0),
 	}
 
 	for i, parameter := range directive.GetParameters() {
@@ -79,6 +91,8 @@ func NewUpstreamServer(directive IDirective) *UpstreamServer {
 			uss.Flags = append(uss.Flags, parameter)
 		}
 	}
+
+	uss.Comment = directive.GetComment()
 
 	return uss
 }


### PR DESCRIPTION
1. Single-line comment
```
# comment: access_log
access_log logs/big.server.access.log main;
```
3. Inline comment
```
server 127.0.0.3:8000 weight=5; # inline comment: server 127.0.0.3:8000 weight=5
server 127.0.0.3:8001 weight=5; # inline comment: server 127.0.0.3:8000 weight=5
```
4. Multiline comment
```
# comment: big_server_com
# comment: upstream big_server_com
upstream big_server_com {
server 127.0.0.3:8000 weight=5;
server 127.0.0.3:8001 weight=5;
server 192.168.0.1:8000;
server 192.168.0.1:8001;
}
```
5. associate comments with config objects to print them on config generation and make it configurable with `dumper.Style`
```
package main

import (
	"fmt"

	"github.com/tufanbarisyildirim/gonginx"
	"github.com/tufanbarisyildirim/gonginx/parser"
)

func main() {
	p := parser.NewStringParser(`user www www;
worker_processes 5;
error_log logs/error.log;
pid logs/nginx.pid;
worker_rlimit_nofile 8192;
events { worker_connections 4096; } 
# http comment
http {
# include comment
include mime.types;
include proxy.conf;
include fastcgi.conf;
index index.html index.htm index.php;
default_type application/octet-stream;
log_format main '$remote_addr - $remote_user [$time_local]  $status '  
'"$request" $body_bytes_sent "$http_referer" '
' "$http_user_agent" "$http_x_forwarded_for"';
access_log logs/access.log main;
sendfile on;
tcp_nopush on;
server_names_hash_bucket_size 128;
server {
listen 80;
server_name domain1.com www.domain1.com;
access_log logs/domain1.access.log main;
root html;
# comment: location
location ~ \.php$ {
fastcgi_pass 127.0.0.1:1025; } } 
# comment: server
server {
listen 80;
server_name domain2.com www.domain2.com;
access_log logs/domain2.access.log main;
location ~ ^/(images|javascript|js|css|flash|media|static)/ {
root /var/www/virtual/big.server.com/htdocs;
expires 30d;
} location / { proxy_pass http://127.0.0.1:8080; } }
# comment: big_server_com
# comment: upstream big_server_com
upstream big_server_com {
server 127.0.0.3:8000 weight=5; # inline comment: server 127.0.0.3:8000 weight=5
server 127.0.0.3:8001 weight=5; # inline comment: server 127.0.0.3:8000 weight=5
server 192.168.0.1:8000;
server 192.168.0.1:8001;
}
# comment: server
server { # comment: listen
listen 80;
server_name big.server.com;
# comment: access_log
access_log logs/big.server.access.log main;
location / { proxy_pass http://big_server_com; } } }`)

	c := p.Parse()
	fmt.Println(gonginx.DumpConfig(c, gonginx.IndentedStyle))

}
```

Output:
```
user www www;
worker_processes 5;
error_log logs/error.log;
pid logs/nginx.pid;
worker_rlimit_nofile 8192;
events {
    worker_connections 4096;
}
# http comment
http {
    # include comment
    include mime.types;
    include proxy.conf;
    include fastcgi.conf;
    index index.html index.htm index.php;
    default_type application/octet-stream;
    log_format main '$remote_addr - $remote_user [$time_local]  $status ' '"$request" $body_bytes_sent "$http_referer" ' ' "$http_user_agent" "$http_x_forwarded_for"';
    access_log logs/access.log main;
    sendfile on;
    tcp_nopush on;
    server_names_hash_bucket_size 128;
    # comment: big_server_com
    # comment: upstream big_server_com
    upstream big_server_com {
        # inline comment: server 127.0.0.3:8000 weight=5
        server 127.0.0.3:8000 weight=5;
        # inline comment: server 127.0.0.3:8000 weight=5
        server 127.0.0.3:8001 weight=5;
        server 192.168.0.1:8000;
        server 192.168.0.1:8001;
    }
    server {
        listen 80;
        server_name domain1.com www.domain1.com;
        access_log logs/domain1.access.log main;
        root html;
        # comment: location
        location ~ \.php$ {
            fastcgi_pass 127.0.0.1:1025;
        }
    }
    # comment: server
    server {
        listen 80;
        server_name domain2.com www.domain2.com;
        access_log logs/domain2.access.log main;
        location ~ ^/(images|javascript|js|css|flash|media|static)/ {
            root /var/www/virtual/big.server.com/htdocs;
            expires 30d;
        }
        location / {
            proxy_pass http://127.0.0.1:8080;
        }
    }
    # comment: server
    server {
        # comment: listen
        listen 80;
        server_name big.server.com;
        # comment: access_log
        access_log logs/big.server.access.log main;
        location / {
            proxy_pass http://big_server_com;
        }
    }
}

```