### PR TITLE
Implement lua block wrapper

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,16 +1,22 @@
 package gonginx
 
-//Block a block statement
+// Block a block statement
 type Block struct {
-	Directives []IDirective
+	Directives  []IDirective
+	IsLuaBlock  bool
+	LiteralCode string
 }
 
-//GetDirectives get all directives in this block
+// GetDirectives get all directives in this block
 func (b *Block) GetDirectives() []IDirective {
 	return b.Directives
 }
 
-//FindDirectives find directives in block recursively
+func (b *Block) GetCodeBlock() string {
+	return b.LiteralCode
+}
+
+// FindDirectives find directives in block recursively
 func (b *Block) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range b.GetDirectives() {

--- a/http.go
+++ b/http.go
@@ -86,3 +86,7 @@ func (h *HTTP) FindDirectives(directiveName string) []IDirective {
 func (h *HTTP) GetBlock() IBlock {
 	return h
 }
+
+func (h *HTTP) GetCodeBlock() string {
+	return ""
+}

--- a/lua_block.go
+++ b/lua_block.go
@@ -1,0 +1,90 @@
+package gonginx
+
+import (
+	"fmt"
+)
+
+// LuaBlock represents *_by_lua_block
+type LuaBlock struct {
+	Directives []IDirective
+	Name       string
+	Comment    []string
+	LuaCode    string
+}
+
+// NewLuaBlock creates a lua block
+func NewLuaBlock(directive IDirective) (*LuaBlock, error) {
+	if block := directive.GetBlock(); block != nil {
+		lb := &LuaBlock{
+			Directives: []IDirective{},
+			Name:       directive.GetName(),
+			LuaCode:    block.GetCodeBlock(),
+		}
+
+		for _, innerDirective := range block.GetDirectives() {
+			lb.Directives = append(lb.Directives, innerDirective)
+		}
+
+		lb.Comment = directive.GetComment()
+
+		return lb, nil
+	}
+	return nil, fmt.Errorf("%s must have a block", directive.GetName())
+}
+
+// GetName get directive name to construct the statment string
+func (lb *LuaBlock) GetName() string { //the directive name.
+	return lb.Name
+}
+
+// GetParameters get directive parameters if any
+func (lb *LuaBlock) GetParameters() []string {
+	return []string{}
+}
+
+// GetDirectives get all directives in lua block
+// this should return 1 code block and that should be it
+func (lb *LuaBlock) GetDirectives() []IDirective {
+	directives := make([]IDirective, 0)
+	directives = append(directives, lb.Directives...)
+	return directives
+}
+
+// FindDirectives find directives
+func (lb *LuaBlock) FindDirectives(directiveName string) []IDirective {
+	directives := make([]IDirective, 0)
+	for _, directive := range lb.GetDirectives() {
+		if directive.GetName() == directiveName {
+			directives = append(directives, directive)
+		}
+		if include, ok := directive.(*Include); ok {
+			for _, c := range include.Configs {
+				directives = append(directives, c.FindDirectives(directiveName)...)
+			}
+		}
+		if directive.GetBlock() != nil {
+			directives = append(directives, directive.GetBlock().FindDirectives(directiveName)...)
+		}
+	}
+
+	return directives
+}
+
+func (lb *LuaBlock) GetCodeBlock() string {
+	return lb.LuaCode
+}
+
+// GetBlock get block if any
+func (lb *LuaBlock) GetBlock() IBlock {
+	return lb
+}
+
+// GetComment get directive comment
+func (lb *LuaBlock) GetComment() []string {
+	return lb.Comment
+}
+
+// SetComment sets comment tied to this directive
+func (lb *LuaBlock) SetComment(comment []string) {
+	lb.Comment = comment
+}

--- a/lua_block.go
+++ b/lua_block.go
@@ -21,10 +21,7 @@ func NewLuaBlock(directive IDirective) (*LuaBlock, error) {
 			LuaCode:    block.GetCodeBlock(),
 		}
 
-		for _, innerDirective := range block.GetDirectives() {
-			lb.Directives = append(lb.Directives, innerDirective)
-		}
-
+		lb.Directives = append(lb.Directives, block.GetDirectives()...)
 		lb.Comment = directive.GetComment()
 
 		return lb, nil

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -151,7 +151,7 @@ server {
 	assert.NilError(t, err)
 	expectJSON, err := json.Marshal(expect)
 	assert.NilError(t, err)
-	assert.Assert(t, actual.EqualTo(expect))
+	assert.NilError(t, actual.Diff(expect))
 	assert.Equal(t, string(tokenString), string(expectJSON))
 	assert.Equal(t, len(actual), len(expect))
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -162,11 +162,11 @@ func (p *Parser) parseBlock() *gonginx.Block {
 	}
 	var s gonginx.IDirective
 	var line int
-parsingloop:
+parsingLoop:
 	for {
 		switch {
 		case p.curTokenIs(token.EOF) || p.curTokenIs(token.BlockEnd):
-			break parsingloop
+			break parsingLoop
 		case p.curTokenIs(token.Keyword) || p.curTokenIs(token.QuotedString):
 			s = p.parseStatement()
 			context.Directives = append(context.Directives, s)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tufanbarisyildirim/gonginx"
 	"github.com/tufanbarisyildirim/gonginx/parser/token"
@@ -119,6 +120,9 @@ func NewParserFromLexer(lexer *lexer, opts ...Option) *Parser {
 		"upstream": func(directive *gonginx.Directive) gonginx.IDirective {
 			return parser.wrapUpstream(directive)
 		},
+		"_by_lua_block": func(directive *gonginx.Directive) gonginx.IDirective {
+			return parser.wrapLuaBlock(directive)
+		},
 	}
 
 	parser.directiveWrappers = map[string]func(*gonginx.Directive) gonginx.IDirective{
@@ -165,6 +169,9 @@ func (p *Parser) parseBlock() *gonginx.Block {
 parsingLoop:
 	for {
 		switch {
+		case p.curTokenIs(token.LuaCode):
+			context.IsLuaBlock = true
+			context.LiteralCode = p.currentToken.Literal
 		case p.curTokenIs(token.EOF) || p.curTokenIs(token.BlockEnd):
 			break parsingLoop
 		case p.curTokenIs(token.Keyword) || p.curTokenIs(token.QuotedString):
@@ -224,6 +231,11 @@ func (p *Parser) parseStatement() gonginx.IDirective {
 	//ok, it does not end with a semicolon but a block starts, we will convert that block if we have a converter
 	if p.curTokenIs(token.BlockStart) {
 		d.Block = p.parseBlock()
+
+		if strings.HasSuffix(d.Name, "_by_lua_block") {
+			return p.blockWrappers["_by_lua_block"](d)
+		}
+
 		if bw, ok := p.blockWrappers[d.Name]; ok {
 			return bw(d)
 		}
@@ -317,6 +329,11 @@ func (p *Parser) wrapServer(directive *gonginx.Directive) *gonginx.Server {
 
 func (p *Parser) wrapUpstream(directive *gonginx.Directive) *gonginx.Upstream {
 	s, _ := gonginx.NewUpstream(directive)
+	return s
+}
+
+func (p *Parser) wrapLuaBlock(directive *gonginx.Directive) *gonginx.LuaBlock {
+	s, _ := gonginx.NewLuaBlock(directive)
 	return s
 }
 

--- a/parser/token/token.go
+++ b/parser/token/token.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-//Type Token.Type
+// Type Token.Type
 type Type int
 
 const (
@@ -49,12 +49,12 @@ var (
 	}
 )
 
-//String convert a token to string as it should be written
+// String convert a token to string as it should be written
 func (tt Type) String() string {
 	return tokenName[tt]
 }
 
-//Token represents a config token
+// Token represents a config token
 type Token struct {
 	Type    Type
 	Literal string
@@ -66,21 +66,21 @@ func (t Token) String() string {
 	return fmt.Sprintf("{Type:%s,Literal:\"%s\",Line:%d,Column:%d}", t.Type, t.Literal, t.Line, t.Column)
 }
 
-//Lit set literal string
+// Lit set literal string
 func (t Token) Lit(literal string) Token {
 	t.Literal = literal
 	return t
 }
 
-//EqualTo checks equality
+// EqualTo checks equality
 func (t Token) EqualTo(t2 Token) bool {
 	return t.Type == t2.Type && t.Literal == t2.Literal
 }
 
-//Tokens list of token
+// Tokens list of token
 type Tokens []Token
 
-//EqualTo check Tokens equality of token list
+// EqualTo check Tokens equality of token list
 func (ts Tokens) EqualTo(tokens Tokens) bool {
 	if len(ts) != len(tokens) {
 		return false
@@ -93,12 +93,29 @@ func (ts Tokens) EqualTo(tokens Tokens) bool {
 	return true
 }
 
-//Is check type of a token
+// Diff find what is difference between two Token collection
+func (ts Tokens) Diff(tokens Tokens) error {
+	if len(ts) != len(tokens) {
+		return fmt.Errorf("different token count %d vs %d", len(ts), len(tokens))
+	}
+	for i, t := range ts {
+		if t.Type != tokens[i].Type {
+			return fmt.Errorf("i=%d,  Type[%s]!=Type[%s]", i, t.Type.String(), tokens[i].Type.String())
+		}
+
+		if !t.EqualTo(tokens[i]) {
+			return fmt.Errorf("tokens are not equal: i=%d, %v!=%v", i, t, tokens[i])
+		}
+	}
+	return nil
+}
+
+// Is check type of a token
 func (t Token) Is(typ Type) bool {
 	return t.Type == typ
 }
 
-//IsParameterEligible checks if token is directive parameter eligible
+// IsParameterEligible checks if token is directive parameter eligible
 func (t Token) IsParameterEligible() bool {
 	return t.Is(Keyword) || t.Is(QuotedString) || t.Is(Variable) || t.Is(Regex)
 }

--- a/statement.go
+++ b/statement.go
@@ -4,6 +4,7 @@ package gonginx
 type IBlock interface {
 	GetDirectives() []IDirective
 	FindDirectives(directiveName string) []IDirective
+	GetCodeBlock() string
 }
 
 // IDirective represents any directive

--- a/testdata/issues/22.conf
+++ b/testdata/issues/22.conf
@@ -1,0 +1,11 @@
+server {
+location = /foo {
+rewrite_by_lua_block {
+res = ngx.location.capture("/memc",
+{ args = { cmd = "incr", key = ngx.var.uri } } # comment contained unexpect '{'
+# comment contained unexpect '}'
+)
+t = { key="foo", val="bar" }
+}
+}
+}

--- a/upstream.go
+++ b/upstream.go
@@ -80,6 +80,10 @@ func (us *Upstream) AddServer(server *UpstreamServer) {
 	us.UpstreamServers = append(us.UpstreamServers, server)
 }
 
+func (us *Upstream) GetCodeBlock() string {
+	return ""
+}
+
 // FindDirectives find directives in block recursively
 func (us *Upstream) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)


### PR DESCRIPTION
this fixes #22 , additionally,
- adds ability to have literal codeblocks with no directives inside (anything works like lua block, needs to be improved tho)
- adds debug mode to the dumper so we can print more expressive config files with debug data in comment lines
- simlyfies the lua block parsing
 