### PR TITLE
enhance: add '' to extra validated directives raw list

### DIFF
--- a/parser/valid_directives.go
+++ b/parser/valid_directives.go
@@ -1,8 +1,6 @@
 package parser
 
-import (
-	"strings"
-)
+import "strings"
 
 // got the list from: https://nginx.org/en/docs/dirindex.html
 var validDirectivesRawList = `absolute_redirect
@@ -719,6 +717,8 @@ zone_sync_ssl_verify_depth
 zone_sync_timeout
 `
 
+var extraValidDirectivesRawList = `''`
+
 // ValidDirectives mapped directives easily find
 // todo: this could handle the allowed blocks as well
 var ValidDirectives map[string]string = map[string]string{}
@@ -726,6 +726,10 @@ var ValidDirectives map[string]string = map[string]string{}
 func init() {
 	directives := strings.Split(validDirectivesRawList, "\n")
 	for _, directive := range directives {
+		ValidDirectives[strings.TrimSpace(directive)] = strings.TrimSpace(directive)
+	}
+	extraDirectives := strings.Split(extraValidDirectivesRawList, "\n")
+	for _, directive := range extraDirectives {
 		ValidDirectives[strings.TrimSpace(directive)] = strings.TrimSpace(directive)
 	}
 }


### PR DESCRIPTION
When parsing the following content in gonginx v2, it will throw a error: unknown directive '''' on line 3, column 5.

```nginx
map $http_upgrade $connection_upgrade {
        default upgrade;
        ''      close;
}
```

However, this configuration is provided by https://nginx.org/en/docs/http/websocket.html. I think we can add a variable of  `extraValidDirectivesRawList` in `parser/valid_directives.go` to handle these directives which are not defined in https://nginx.org/en/docs/dirindex.html.