### PR TITLE
fix unexpected token BlockEnd (})

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -258,7 +258,7 @@ func (p *Parser) parseStatement(isSkipValidDirective bool) (config.IDirective, e
 	//parse parameters until the end.
 	for p.nextToken(); p.currentToken.IsParameterEligible(); p.nextToken() {
 		d.Parameters = append(d.Parameters, p.currentToken.Literal)
-		if p.followingToken.Is(token.BlockEnd) {
+		if p.currentToken.Is(token.BlockEnd) {
 			return d, nil
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -258,6 +258,9 @@ func (p *Parser) parseStatement(isSkipValidDirective bool) (config.IDirective, e
 	//parse parameters until the end.
 	for p.nextToken(); p.currentToken.IsParameterEligible(); p.nextToken() {
 		d.Parameters = append(d.Parameters, p.currentToken.Literal)
+		if p.followingToken.Is(token.BlockEnd) {
+			return d, nil
+		}
 	}
 
 	//if we find a semicolon it is a directive, we will check directive converters


### PR DESCRIPTION
fix this issue https://github.com/tufanbarisyildirim/gonginx/issues/48
When the parser encounters a keyword type and enters parseStatement, during the process of parsing parameters until the end, if the end is directly a BlockEnd, it cannot match and correctly exit the parseStatement function. Therefore, when looping to match until exiting parseStatement, it is necessary to first check if the next token is BlockEnd, and if so, return and exit directly.
@tufanbarisyildirim 