### PR TITLE
Fix: #59 support the ability to get the line number where the nginx directive is located

### DIFF
--- a/config/directive.go
+++ b/config/directive.go
@@ -8,6 +8,17 @@ type Directive struct {
 	Comment    []string
 	DefaultInlineComment
 	Parent IBlock
+	Line   int
+}
+
+// SetLine Set line number
+func (d *Directive) SetLine(line int) {
+	d.Line = line
+}
+
+// GetLine Get the line number
+func (d *Directive) GetLine() int {
+	return d.Line
 }
 
 // SetParent  the parent block

--- a/config/http.go
+++ b/config/http.go
@@ -11,6 +11,17 @@ type HTTP struct {
 	Comment    []string
 	DefaultInlineComment
 	Parent IBlock
+	Line   int
+}
+
+// SetLine Set line number
+func (h *HTTP) SetLine(line int) {
+	h.Line = line
+}
+
+// GetLine Get the line number
+func (h *HTTP) GetLine() int {
+	return h.Line
 }
 
 // SetParent change the parent block

--- a/config/include.go
+++ b/config/include.go
@@ -27,6 +27,16 @@ type Include struct {
 //	return nil
 //}
 
+// SetLine Set line number
+func (c *Include) SetLine(line int) {
+	c.Line = line
+}
+
+// GetLine Get the line number
+func (c *Include) GetLine() int {
+	return c.Line
+}
+
 // GetParent the parent block
 func (c *Include) GetParent() IBlock {
 	return c.Parent

--- a/config/location.go
+++ b/config/location.go
@@ -8,6 +8,17 @@ type Location struct {
 	Modifier string
 	Match    string
 	Parent   IBlock
+	Line     int
+}
+
+// SetLine Set line number
+func (l *Location) SetLine(line int) {
+	l.Line = line
+}
+
+// GetLine Get the line number
+func (l *Location) GetLine() int {
+	return l.Line
 }
 
 // SetParent change the parent block

--- a/config/lua_block.go
+++ b/config/lua_block.go
@@ -12,6 +12,7 @@ type LuaBlock struct {
 	DefaultInlineComment
 	LuaCode string
 	Parent  IBlock
+	Line    int
 }
 
 // NewLuaBlock creates a lua block
@@ -30,6 +31,16 @@ func NewLuaBlock(directive IDirective) (*LuaBlock, error) {
 		return lb, nil
 	}
 	return nil, fmt.Errorf("%s must have a block", directive.GetName())
+}
+
+// SetLine Set line number
+func (lb *LuaBlock) SetLine(line int) {
+	lb.Line = line
+}
+
+// GetLine Get the line number
+func (lb *LuaBlock) GetLine() int {
+	return lb.Line
 }
 
 // SetParent change the parent block

--- a/config/server.go
+++ b/config/server.go
@@ -10,6 +10,17 @@ type Server struct {
 	Comment []string
 	DefaultInlineComment
 	Parent IBlock
+	Line   int
+}
+
+// SetLine Set line number
+func (s *Server) SetLine(line int) {
+	s.Line = line
+}
+
+// GetLine Get the line number
+func (s *Server) GetLine() int {
+	return s.Line
 }
 
 // SetParent change the parent block

--- a/config/statement.go
+++ b/config/statement.go
@@ -18,6 +18,8 @@ type IDirective interface {
 	SetComment(comment []string)
 	SetParent(IBlock)
 	GetParent() IBlock
+	GetLine() int
+	SetLine(int)
 	InlineCommenter
 }
 

--- a/config/upstream.go
+++ b/config/upstream.go
@@ -13,6 +13,17 @@ type Upstream struct {
 	Comment    []string
 	DefaultInlineComment
 	Parent IBlock
+	Line   int
+}
+
+// SetLine Set line number
+func (us *Upstream) SetLine(line int) {
+	us.Line = line
+}
+
+// GetLine Get the line number
+func (us *Upstream) GetLine() int {
+	return us.Line
 }
 
 // SetParent change the parent block
@@ -80,6 +91,7 @@ func NewUpstream(directive IDirective) (*Upstream, error) {
 					return nil, err
 				}
 				uss.SetParent(us)
+				uss.SetLine(d.GetLine())
 				us.UpstreamServers = append(us.UpstreamServers, uss)
 			} else {
 				us.Directives = append(us.Directives, d)

--- a/config/upstream_server.go
+++ b/config/upstream_server.go
@@ -14,6 +14,17 @@ type UpstreamServer struct {
 	Comment    []string
 	DefaultInlineComment
 	Parent IBlock
+	Line   int
+}
+
+// SetLine Set line number
+func (uss *UpstreamServer) SetLine(line int) {
+	uss.Line = line
+}
+
+// GetLine Get the line number
+func (uss *UpstreamServer) GetLine() int {
+	return uss.Line
 }
 
 // SetParent change the parent block

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -220,8 +220,9 @@ parsingLoop:
 				return nil, err
 			}
 			s.SetParent(context)
-			context.Directives = append(context.Directives, s)
 			line = p.currentToken.Line
+			s.SetLine(line)
+			context.Directives = append(context.Directives, s)
 		case p.curTokenIs(token.Comment):
 			if p.opts.skipComments {
 				break
@@ -232,6 +233,7 @@ parsingLoop:
 					s = context.Directives[len(context.Directives)-1]
 				}
 				s.SetInlineComment(p.currentToken.Literal)
+				s.SetLine(line)
 				p.commentBuffer = nil
 			} else {
 				p.commentBuffer = append(p.commentBuffer, p.currentToken.Literal)


### PR DESCRIPTION
Support the ability to get the line number where the nginx directive is located.

This PR is for Issue: #59, which supports parsing of nginx directives to get the line number in the configuration file where the directive is located.

 I hope it will be merged.