### PR TITLE
#54 Keep parameters in their relative lines when in multi-line configuration.

### DIFF
--- a/config/block_test.go
+++ b/config/block_test.go
@@ -30,7 +30,7 @@ func TestBlock_FindDirectives(t *testing.T) {
 							Directives: []IDirective{
 								&Directive{
 									Name:       "server_name",
-									Parameters: []string{"gonginx.dev"},
+									Parameters: []Parameter{{Value: "gonginx.dev"}},
 								},
 							},
 						},
@@ -40,7 +40,7 @@ func TestBlock_FindDirectives(t *testing.T) {
 							Directives: []IDirective{
 								&Directive{
 									Name:       "server_name",
-									Parameters: []string{"gonginx2.dev"},
+									Parameters: []Parameter{{Value: "gonginx2.dev"}},
 								},
 							},
 						},
@@ -52,7 +52,7 @@ func TestBlock_FindDirectives(t *testing.T) {
 									Directives: []IDirective{
 										&Directive{
 											Name:       "server_name",
-											Parameters: []string{"gonginx3.dev"},
+											Parameters: []Parameter{{Value: "gonginx3.dev"}},
 										},
 									},
 								},
@@ -67,7 +67,7 @@ func TestBlock_FindDirectives(t *testing.T) {
 						Directives: []IDirective{
 							&Directive{
 								Name:       "server_name",
-								Parameters: []string{"gonginx.dev"},
+								Parameters: []Parameter{{Value: "gonginx.dev"}},
 							},
 						},
 					},
@@ -77,7 +77,7 @@ func TestBlock_FindDirectives(t *testing.T) {
 						Directives: []IDirective{
 							&Directive{
 								Name:       "server_name",
-								Parameters: []string{"gonginx2.dev"},
+								Parameters: []Parameter{{Value: "gonginx2.dev"}},
 							},
 						},
 					},
@@ -87,7 +87,7 @@ func TestBlock_FindDirectives(t *testing.T) {
 						Directives: []IDirective{
 							&Directive{
 								Name:       "server_name",
-								Parameters: []string{"gonginx3.dev"},
+								Parameters: []Parameter{{Value: "gonginx3.dev"}},
 							},
 						},
 					},

--- a/config/directive.go
+++ b/config/directive.go
@@ -4,7 +4,7 @@ package config
 type Directive struct {
 	Block      IBlock
 	Name       string
-	Parameters []string //TODO: Save parameters with their type
+	Parameters []Parameter //TODO: Save parameters with their type
 	Comment    []string
 	DefaultInlineComment
 	Parent IBlock
@@ -31,7 +31,7 @@ func (d *Directive) GetName() string {
 }
 
 // GetParameters get all parameters of a directive
-func (d *Directive) GetParameters() []string {
+func (d *Directive) GetParameters() []Parameter {
 	return d.Parameters
 }
 

--- a/config/http.go
+++ b/config/http.go
@@ -62,8 +62,8 @@ func (h *HTTP) GetName() string { //the directive name.
 }
 
 // GetParameters get directive parameters if any
-func (h *HTTP) GetParameters() []string {
-	return []string{}
+func (h *HTTP) GetParameters() []Parameter {
+	return []Parameter{}
 }
 
 // GetDirectives get all directives in http

--- a/config/include.go
+++ b/config/include.go
@@ -75,7 +75,7 @@ func NewInclude(dir IDirective) (*Include, error) {
 	}
 	include := &Include{
 		Directive:   directive,
-		IncludePath: directive.Parameters[0],
+		IncludePath: directive.Parameters[0].GetValue(),
 	}
 
 	if len(directive.Parameters) > 1 {

--- a/config/location.go
+++ b/config/location.go
@@ -36,11 +36,11 @@ func NewLocation(directive IDirective) (*Location, error) {
 		Directive: dir,
 	}
 	if len(dir.Parameters) == 1 {
-		location.Match = dir.Parameters[0]
+		location.Match = dir.Parameters[0].GetValue()
 		return location, nil
 	} else if len(dir.Parameters) == 2 {
-		location.Modifier = dir.Parameters[0]
-		location.Match = dir.Parameters[1]
+		location.Modifier = dir.Parameters[0].GetValue()
+		location.Match = dir.Parameters[1].GetValue()
 		return location, nil
 	}
 	return nil, errors.New("too many arguments for location directive")

--- a/config/lua_block.go
+++ b/config/lua_block.go
@@ -48,8 +48,8 @@ func (lb *LuaBlock) GetName() string { //the directive name.
 }
 
 // GetParameters get directive parameters if any
-func (lb *LuaBlock) GetParameters() []string {
-	return []string{}
+func (lb *LuaBlock) GetParameters() []Parameter {
+	return []Parameter{}
 }
 
 // GetDirectives get all directives in lua block

--- a/config/server.go
+++ b/config/server.go
@@ -50,8 +50,8 @@ func (s *Server) GetName() string { //the directive name.
 }
 
 // GetParameters get directive parameters if any
-func (s *Server) GetParameters() []string {
-	return []string{}
+func (s *Server) GetParameters() []Parameter {
+	return []Parameter{}
 }
 
 // GetBlock get block if any

--- a/config/statement.go
+++ b/config/statement.go
@@ -58,22 +58,27 @@ type Parameter struct {
 	RelativeLineIndex int // relative line index to the directive
 }
 
+// String returns the value of the parameter
 func (p *Parameter) String() string {
 	return p.Value
 }
 
+// SetValue sets the value of the parameter
 func (p *Parameter) SetValue(v string) {
 	p.Value = v
 }
 
+// GetValue returns the value of the parameter
 func (p *Parameter) GetValue() string {
 	return p.Value
 }
 
+// SetRelativeLineIndex sets the relative line index of the parameter
 func (p *Parameter) SetRelativeLineIndex(i int) {
 	p.RelativeLineIndex = i
 }
 
+// GetRelativeLineIndex returns the relative line index of the parameter
 func (p *Parameter) GetRelativeLineIndex() int {
 	return p.RelativeLineIndex
 }

--- a/config/statement.go
+++ b/config/statement.go
@@ -12,7 +12,7 @@ type IBlock interface {
 // IDirective represents any directive
 type IDirective interface {
 	GetName() string //the directive name.
-	GetParameters() []string
+	GetParameters() []Parameter
 	GetBlock() IBlock
 	GetComment() []string
 	SetComment(comment []string)
@@ -50,4 +50,30 @@ type FileDirective interface {
 // IncludeDirective represents include statement in nginx
 type IncludeDirective interface {
 	FileDirective
+}
+
+// Parameter represents a parameter in a directive
+type Parameter struct {
+	Value             string
+	RelativeLineIndex int // relative line index to the directive
+}
+
+func (p *Parameter) String() string {
+	return p.Value
+}
+
+func (p *Parameter) SetValue(v string) {
+	p.Value = v
+}
+
+func (p *Parameter) GetValue() string {
+	return p.Value
+}
+
+func (p *Parameter) SetRelativeLineIndex(i int) {
+	p.RelativeLineIndex = i
+}
+
+func (p *Parameter) GetRelativeLineIndex() int {
+	return p.RelativeLineIndex
 }

--- a/config/upstream.go
+++ b/config/upstream.go
@@ -36,8 +36,8 @@ func (us *Upstream) GetName() string {
 }
 
 // GetParameters upsrema parameters
-func (us *Upstream) GetParameters() []string {
-	return []string{us.UpstreamName} //the only parameter for an upstream is its name
+func (us *Upstream) GetParameters() []Parameter {
+	return []Parameter{{Value: us.UpstreamName}} //the only parameter for an upstream is its name
 }
 
 // GetBlock upstream does not have block
@@ -65,7 +65,7 @@ func (us *Upstream) GetDirectives() []IDirective {
 func NewUpstream(directive IDirective) (*Upstream, error) {
 	parameters := directive.GetParameters()
 	us := &Upstream{
-		UpstreamName: parameters[0], //first parameter of the directive is the upstream name
+		UpstreamName: parameters[0].GetValue(), //first parameter of the directive is the upstream name
 	}
 
 	if directive.GetBlock() == nil {

--- a/dumper/block_test.go
+++ b/dumper/block_test.go
@@ -34,12 +34,15 @@ func TestBlock_ToString(t *testing.T) {
 			fields: fields{
 				Directives: []config.IDirective{
 					&config.Directive{
-						Name:       "user",
-						Parameters: []string{"nginx", "nginx"},
+						Name: "user",
+						Parameters: []config.Parameter{
+							{Value: "nginx"},
+							{Value: "nginx"},
+						},
 					},
 					&config.Directive{
 						Name:       "worker_processes",
-						Parameters: []string{"5"},
+						Parameters: []config.Parameter{{Value: "5"}},
 					},
 				},
 			},
@@ -52,17 +55,19 @@ func TestBlock_ToString(t *testing.T) {
 			fields: fields{
 				Directives: []config.IDirective{
 					&config.Directive{
-						Name:       "user",
-						Parameters: []string{"nginx", "nginx"},
+						Name: "user",
+						Parameters: []config.Parameter{
+							{Value: "nginx"},
+							{Value: "nginx"}},
 					},
 					&config.Directive{
 						Name:       "worker_processes",
-						Parameters: []string{"5"},
+						Parameters: []config.Parameter{{Value: "5"}},
 					},
 					&config.Include{
 						Directive: &config.Directive{
 							Name:       "include",
-							Parameters: []string{"/etc/nginx/conf/*.conf"},
+							Parameters: []config.Parameter{{Value: "/etc/nginx/conf/*.conf"}},
 						},
 						IncludePath: "/etc/nginx/conf/*.conf",
 					},
@@ -70,17 +75,20 @@ func TestBlock_ToString(t *testing.T) {
 						Block: &config.Block{
 							Directives: []config.IDirective{
 								&config.Directive{
-									Name:       "user",
-									Parameters: []string{"nginx", "nginx"},
+									Name: "user",
+									Parameters: []config.Parameter{
+										{Value: "nginx"},
+										{Value: "nginx"},
+									},
 								},
 								&config.Directive{
 									Name:       "worker_processes",
-									Parameters: []string{"5"},
+									Parameters: []config.Parameter{{Value: "5"}},
 								},
 								&config.Include{
 									Directive: &config.Directive{
 										Name:       "include",
-										Parameters: []string{"/etc/nginx/conf/*.conf"},
+										Parameters: []config.Parameter{{Value: "/etc/nginx/conf/*.conf"}},
 									},
 									IncludePath: "/etc/nginx/conf/*.conf",
 								},

--- a/dumper/config_test.go
+++ b/dumper/config_test.go
@@ -23,17 +23,20 @@ func TestConfig_ToString(t *testing.T) {
 				Block: &config.Block{
 					Directives: []config.IDirective{
 						&config.Directive{
-							Name:       "user",
-							Parameters: []string{"nginx", "nginx"},
+							Name: "user",
+							Parameters: []config.Parameter{
+								{Value: "nginx"},
+								{Value: "nginx"},
+							},
 						},
 						&config.Directive{
 							Name:       "worker_processes",
-							Parameters: []string{"5"},
+							Parameters: []config.Parameter{{Value: "5"}},
 						},
 						&config.Include{
 							Directive: &config.Directive{
 								Name:       "include",
-								Parameters: []string{"/etc/nginx/conf/*.conf"},
+								Parameters: []config.Parameter{{Value: "/etc/nginx/conf/*.conf"}},
 							},
 							IncludePath: "/etc/nginx/conf/*.conf",
 						},

--- a/dumper/directive_test.go
+++ b/dumper/directive_test.go
@@ -10,7 +10,7 @@ func TestDirective_ToString(t *testing.T) {
 	t.Parallel()
 	type fields struct {
 		Name       string
-		Parameters []string
+		Parameters []config.Parameter
 	}
 	tests := []struct {
 		name   string
@@ -21,10 +21,10 @@ func TestDirective_ToString(t *testing.T) {
 			name: "server_name direction",
 			fields: fields{
 				Name: "server_name",
-				Parameters: []string{
-					"gonginx.dev",
-					"gonginx.local",
-					"microspector.com",
+				Parameters: []config.Parameter{
+					{Value: "gonginx.dev"},
+					{Value: "gonginx.local"},
+					{Value: "microspector.com"},
 				},
 			},
 			want: "server_name gonginx.dev gonginx.local microspector.com;",
@@ -33,8 +33,8 @@ func TestDirective_ToString(t *testing.T) {
 			name: "proxy_pass direction",
 			fields: fields{
 				Name: "proxy_pass",
-				Parameters: []string{
-					"http://127.0.0.1/",
+				Parameters: []config.Parameter{
+					{Value: "http://127.0.0.1/"},
 				},
 			},
 			want: "proxy_pass http://127.0.0.1/;",
@@ -43,9 +43,9 @@ func TestDirective_ToString(t *testing.T) {
 			name: "proxy_set_header direction",
 			fields: fields{
 				Name: "proxy_set_header",
-				Parameters: []string{
-					"Host",
-					"$host",
+				Parameters: []config.Parameter{
+					{Value: "Host"},
+					{Value: "$host"},
 				},
 			},
 			want: "proxy_set_header Host $host;",
@@ -54,9 +54,9 @@ func TestDirective_ToString(t *testing.T) {
 			name: "proxy_buffers direction",
 			fields: fields{
 				Name: "proxy_buffers",
-				Parameters: []string{
-					"4",
-					"32k",
+				Parameters: []config.Parameter{
+					{Value: "4"},
+					{Value: "32k"},
 				},
 			},
 			want: "proxy_buffers 4 32k;",
@@ -65,8 +65,8 @@ func TestDirective_ToString(t *testing.T) {
 			name: "charset direction",
 			fields: fields{
 				Name: "charset",
-				Parameters: []string{
-					"koi8-r",
+				Parameters: []config.Parameter{
+					{Value: "koi8-r"},
 				},
 			},
 			want: "charset koi8-r;",
@@ -75,8 +75,8 @@ func TestDirective_ToString(t *testing.T) {
 			name: "'' close",
 			fields: fields{
 				Name: "''",
-				Parameters: []string{
-					"close",
+				Parameters: []config.Parameter{
+					{Value: "close"},
 				},
 			},
 			want: "'' close;",

--- a/dumper/dumper.go
+++ b/dumper/dumper.go
@@ -95,7 +95,18 @@ func DumpDirective(d config.IDirective, style *Style) string {
 	}
 	buf.WriteString(fmt.Sprintf("%s%s", strings.Repeat(" ", style.StartIndent), d.GetName()))
 	if len(d.GetParameters()) > 0 {
-		buf.WriteString(fmt.Sprintf(" %s", strings.Join(d.GetParameters(), " ")))
+		// Use relative line index to handle different line number arrangements of instruction parameters
+		relativeLineIndex := 0
+		for _, parameter := range d.GetParameters() {
+			// If the parameter line index is not the same as the previous one, add a new line
+			if parameter.GetRelativeLineIndex() != relativeLineIndex {
+				buf.WriteString("\n")
+				buf.WriteString(fmt.Sprintf("%s%s", strings.Repeat(" ", style.StartIndent), parameter.GetValue()))
+				relativeLineIndex = parameter.GetRelativeLineIndex()
+			} else {
+				buf.WriteString(fmt.Sprintf(" %s", parameter.GetValue()))
+			}
+		}
 	}
 	if d.GetBlock() == nil {
 		if d.GetName() != "" {

--- a/dumper/http_test.go
+++ b/dumper/http_test.go
@@ -39,11 +39,11 @@ func TestHttp_ToString(t *testing.T) {
 						Directives: []config.IDirective{
 							&config.Directive{
 								Name:       "access_log",
-								Parameters: []string{"logs/access.log", "main"},
+								Parameters: []config.Parameter{{Value: "logs/access.log"}, {Value: "main"}},
 							},
 							&config.Directive{
 								Name:       "default_type",
-								Parameters: []string{"application/octet-stream"},
+								Parameters: []config.Parameter{{Value: "application/octet-stream"}},
 							},
 						},
 					},

--- a/dumper/include_test.go
+++ b/dumper/include_test.go
@@ -12,7 +12,7 @@ func TestConfig_IncludeToString(t *testing.T) {
 	include := &config.Include{
 		Directive: &config.Directive{
 			Name:       "include",
-			Parameters: []string{"/etc/nginx/conf.d/*.conf"},
+			Parameters: []config.Parameter{{Value: "/etc/nginx/conf.d/*.conf"}},
 		},
 		IncludePath: "/etc/nginx/conf.d/*.conf",
 	}

--- a/dumper/location_test.go
+++ b/dumper/location_test.go
@@ -23,7 +23,7 @@ func TestLocation_ToString(t *testing.T) {
 			fields: fields{
 				Directive: &config.Directive{
 					Name:       "location",
-					Parameters: []string{"/admin"},
+					Parameters: []config.Parameter{{Value: "/admin"}},
 					Block: &config.Block{
 						Directives: make([]config.IDirective, 0),
 					},

--- a/dumper/server_test.go
+++ b/dumper/server_test.go
@@ -38,11 +38,11 @@ func TestServer_ToString(t *testing.T) {
 						Directives: []config.IDirective{
 							&config.Directive{
 								Name:       "server_name",
-								Parameters: []string{"gonginx.dev"},
+								Parameters: []config.Parameter{{Value: "gonginx.dev"}},
 							},
 							&config.Directive{
 								Name:       "root",
-								Parameters: []string{"/var/sites/gonginx"},
+								Parameters: []config.Parameter{{Value: "/var/sites/gonginx"}},
 							},
 						},
 					},

--- a/dumper/upstream_server_test.go
+++ b/dumper/upstream_server_test.go
@@ -24,7 +24,7 @@ func TestNewUpstreamServer(t *testing.T) {
 			args: args{
 				directive: &config.Directive{
 					Name:       "server",
-					Parameters: []string{"127.0.0.1:8080"},
+					Parameters: []config.Parameter{{Value: "127.0.0.1:8080"}},
 				},
 			},
 			want: &config.UpstreamServer{
@@ -39,7 +39,7 @@ func TestNewUpstreamServer(t *testing.T) {
 			args: args{
 				directive: &config.Directive{
 					Name:       "server",
-					Parameters: []string{"127.0.0.1:8080", "weight=5"},
+					Parameters: []config.Parameter{{Value: "127.0.0.1:8080"}, {Value: "weight=5"}},
 				},
 			},
 			want: &config.UpstreamServer{
@@ -56,7 +56,7 @@ func TestNewUpstreamServer(t *testing.T) {
 			args: args{
 				directive: &config.Directive{
 					Name:       "server",
-					Parameters: []string{"127.0.0.1:8080", "weight=5", "down"},
+					Parameters: []config.Parameter{{Value: "127.0.0.1:8080"}, {Value: "weight=5"}, {Value: "down"}},
 				},
 			},
 			want: &config.UpstreamServer{

--- a/dumper/upstream_test.go
+++ b/dumper/upstream_test.go
@@ -23,7 +23,7 @@ func TestUpstream_ToString(t *testing.T) {
 			fields: fields{
 				Directive: &config.Directive{
 					Name:       "upstream",
-					Parameters: []string{"gonginx_upstream"},
+					Parameters: []config.Parameter{{Value: "gonginx_upstream"}},
 					Block: &config.Block{
 						Directives: make([]config.IDirective, 0),
 					},
@@ -36,12 +36,12 @@ func TestUpstream_ToString(t *testing.T) {
 			fields: fields{
 				Directive: &config.Directive{
 					Name:       "upstream",
-					Parameters: []string{"gonginx_upstream"},
+					Parameters: []config.Parameter{{Value: "gonginx_upstream"}},
 					Block: &config.Block{
 						Directives: []config.IDirective{
 							NewUpstreamServerIgnoreErr(&config.Directive{
 								Name:       "server",
-								Parameters: []string{"127.0.0.1:9005"},
+								Parameters: []config.Parameter{{Value: "127.0.0.1:9005"}},
 							}),
 						},
 					},
@@ -54,16 +54,16 @@ func TestUpstream_ToString(t *testing.T) {
 			fields: fields{
 				Directive: &config.Directive{
 					Name:       "upstream",
-					Parameters: []string{"gonginx_upstream"},
+					Parameters: []config.Parameter{{Value: "gonginx_upstream"}},
 					Block: &config.Block{
 						Directives: []config.IDirective{
 							NewUpstreamServerIgnoreErr(&config.Directive{
 								Name:       "server",
-								Parameters: []string{"127.0.0.1:9005"},
+								Parameters: []config.Parameter{{Value: "127.0.0.1:9005"}},
 							}),
 							NewUpstreamServerIgnoreErr(&config.Directive{
 								Name:       "server",
-								Parameters: []string{"127.0.0.2:9005"},
+								Parameters: []config.Parameter{{Value: "127.0.0.2:9005"}},
 							}),
 						},
 					},
@@ -76,16 +76,16 @@ func TestUpstream_ToString(t *testing.T) {
 			fields: fields{
 				Directive: &config.Directive{
 					Name:       "upstream",
-					Parameters: []string{"gonginx_upstream"},
+					Parameters: []config.Parameter{{Value: "gonginx_upstream"}},
 					Block: &config.Block{
 						Directives: []config.IDirective{
 							NewUpstreamServerIgnoreErr(&config.Directive{
 								Name:       "server",
-								Parameters: []string{"127.0.0.1:9005", "weight=5"},
+								Parameters: []config.Parameter{{Value: "127.0.0.1:9005"}, {Value: "weight=5"}},
 							}),
 							NewUpstreamServerIgnoreErr(&config.Directive{
 								Name:       "server",
-								Parameters: []string{"127.0.0.2:9005", "weight=4", "down"},
+								Parameters: []config.Parameter{{Value: "127.0.0.2:9005"}, {Value: "weight=4"}, {Value: "down"}},
 							}),
 						},
 					},

--- a/examples/add-custom-directive/main.go
+++ b/examples/add-custom-directive/main.go
@@ -24,7 +24,7 @@ func addCustomDirective(fullConf string, blockName string, directiveName string,
 	block := blocks[0].GetBlock()
 	newDirective := &config.Directive{
 		Name:       directiveName,
-		Parameters: []string{directiveValue},
+		Parameters: []config.Parameter{{Value: directiveValue}},
 	}
 	realBlock := block.(*config.Block)
 	realBlock.Directives = append(realBlock.Directives, newDirective)

--- a/examples/parse-nginx-conf-get-listen-port/main.go
+++ b/examples/parse-nginx-conf-get-listen-port/main.go
@@ -21,7 +21,9 @@ func parseConfigAndGetPorts(filePath string) ([]string, error) {
 		listens := server.GetBlock().FindDirectives("listen")
 		if len(listens) > 0 {
 			listenPorts := listens[0].GetParameters()
-			ports = append(ports, listenPorts...)
+			for _, port := range listenPorts {
+				ports = append(ports, port.GetValue())
+			}
 		}
 	}
 	return ports, nil

--- a/examples/update-directive/main.go
+++ b/examples/update-directive/main.go
@@ -68,8 +68,8 @@ http {
 	directives := c.FindDirectives("proxy_pass")
 	for _, directive := range directives {
 		fmt.Println("found a proxy_pass :  ", directive.GetName(), directive.GetParameters())
-		if directive.GetParameters()[0] == "http://www.google.com/" {
-			directive.GetParameters()[0] = "http://www.duckduckgo.com/"
+		if directive.GetParameters()[0].GetValue() == "http://www.google.com/" {
+			directive.GetParameters()[0].SetValue("http://www.duckduckgo.com/")
 		}
 	}
 

--- a/examples/update-server-listen-port/main.go
+++ b/examples/update-server-listen-port/main.go
@@ -23,9 +23,9 @@ func updateServerListenPort(filePath string, oldPort string, newPort string) (st
 	for _, server := range servers {
 		listens := server.GetBlock().FindDirectives("listen")
 		for _, listen := range listens {
-			if listen.GetParameters()[0] == oldPort {
+			if listen.GetParameters()[0].GetValue() == oldPort {
 				listenDirective := listen.(*config.Directive)
-				listenDirective.Parameters[0] = newPort
+				listenDirective.Parameters[0].SetValue(newPort)
 			}
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -269,8 +269,12 @@ func (p *Parser) parseStatement(isSkipValidDirective bool) (config.IDirective, e
 	}
 
 	//parse parameters until the end.
+	// keep track of the line index of the directive
+	directiveLineIndex := p.currentToken.Line
 	for p.nextToken(); p.currentToken.IsParameterEligible(); p.nextToken() {
-		d.Parameters = append(d.Parameters, p.currentToken.Literal)
+		d.Parameters = append(d.Parameters, config.Parameter{
+			Value:             p.currentToken.Literal,
+			RelativeLineIndex: p.currentToken.Line - directiveLineIndex}) // save the relative line index of the parameter
 		if p.currentToken.Is(token.BlockEnd) {
 			return d, nil
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -161,8 +161,8 @@ func TestParser_VariableAsParameter(t *testing.T) {
 	assert.Assert(t, ok, "expecting a directive(http) as first statement")
 	assert.Equal(t, d.Name, "map", "first directive needs to be ")
 	assert.Equal(t, len(d.Parameters), 2, "map must have 2 parameters here")
-	assert.Equal(t, d.Parameters[0], "$host", "invalid first parameter")
-	assert.Equal(t, d.Parameters[1], "$clientname", "invalid second parameter")
+	assert.Equal(t, d.Parameters[0].GetValue(), "$host", "invalid first parameter")
+	assert.Equal(t, d.Parameters[1].GetValue(), "$clientname", "invalid second parameter")
 }
 
 func TestParser_UnendedMultiParams(t *testing.T) {
@@ -525,4 +525,31 @@ http {
 	includes := httpBlock.FindDirectives("include")
 
 	assert.Equal(t, len(includes), 1, "cannot find include directive in http block")
+}
+
+func TestParser_KeepDataInMultiLine01(t *testing.T) {
+	p := NewStringParser(`log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+'$status $body_bytes_sent "$http_referer" '
+'"$http_user_agent" "$http_x_forwarded_for"';`)
+	conf, err := p.Parse()
+	assert.NilError(t, err, "no error expected here")
+	s := dumper.DumpConfig(conf, dumper.IndentedStyle)
+	assert.Equal(t, `log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+'$status $body_bytes_sent "$http_referer" '
+'"$http_user_agent" "$http_x_forwarded_for"';`, s)
+
+}
+
+func TestParser_KeepDataInMultiLine02(t *testing.T) {
+	p := NewStringParser(`events {
+	worker_connections
+	4096;}`)
+	conf, err := p.Parse()
+	assert.NilError(t, err, "no error expected here")
+	s := dumper.DumpConfig(conf, dumper.IndentedStyle)
+	assert.Equal(t, `events {
+    worker_connections
+    4096;
+}`, s)
+
 }


### PR DESCRIPTION
1. Migrate all directive parameters to the Parameter object
2. The Parameter object stores the relative line index to the directive, allowing the dump to retain the original layout
3. During parsing, obtain and store the relative line index of parameters to the directive
4. During dump, restore the original relative line index