### PR TITLE
Fix/get more than2 level parent directive err

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -364,8 +364,8 @@ type IDirective interface {
 	GetBlock() IBlock
 	GetComment() []string
 	SetComment(comment []string)
-	SetParent(IBlock)
-	GetParent() IBlock
+	SetParent(IDirective)
+	GetParent() IDirective
 }
 ```
 + GetName() string: the directive name.
@@ -373,21 +373,21 @@ type IDirective interface {
 + GetBlock() IBlock: the directive block.
 + GetComment() []string: the directive comment.
 + SetComment(comment []string): the directive comment.
-+ GetParent() IBlock: the directive parent block.
++ GetParent() IDirective: the directive that contains or encloses the current directive.
 #### IBlock
 ```go
 type IBlock interface {
 	GetDirectives() []IDirective
 	FindDirectives(directiveName string) []IDirective
 	GetCodeBlock() string
-	SetParent(IBlock)
-	GetParent() IBlock
+	SetParent(IDirective)
+	GetParent() IDirective
 }
 ```
 + GetDirectives() []IDirective: the block directives.
 + FindDirectives(directiveName string) []IDirective: the block directives.
 + GetCodeBlock() string: the block code.
-+ GetParent() IBlock: the block parent block.
++ GetParent() IDirective: the directive that contains or encloses the current directive.
 
 #### Directive (impl IDirective)
 ```go

--- a/config/block.go
+++ b/config/block.go
@@ -5,16 +5,16 @@ type Block struct {
 	Directives  []IDirective
 	IsLuaBlock  bool
 	LiteralCode string
-	Parent      IBlock
+	Parent      IDirective
 }
 
 // SetParent change the parent block
-func (b *Block) SetParent(parent IBlock) {
+func (b *Block) SetParent(parent IDirective) {
 	b.Parent = parent
 }
 
 // GetParent the parent block
-func (b *Block) GetParent() IBlock {
+func (b *Block) GetParent() IDirective {
 	return b.Parent
 }
 

--- a/config/directive.go
+++ b/config/directive.go
@@ -7,7 +7,7 @@ type Directive struct {
 	Parameters []Parameter //TODO: Save parameters with their type
 	Comment    []string
 	DefaultInlineComment
-	Parent IBlock
+	Parent IDirective
 	Line   int
 }
 
@@ -22,12 +22,12 @@ func (d *Directive) GetLine() int {
 }
 
 // SetParent  the parent block
-func (d *Directive) SetParent(parent IBlock) {
+func (d *Directive) SetParent(parent IDirective) {
 	d.Parent = parent
 }
 
 // GetParent change the parent block
-func (d *Directive) GetParent() IBlock {
+func (d *Directive) GetParent() IDirective {
 	return d.Parent
 }
 

--- a/config/http.go
+++ b/config/http.go
@@ -10,7 +10,7 @@ type HTTP struct {
 	Directives []IDirective
 	Comment    []string
 	DefaultInlineComment
-	Parent IBlock
+	Parent IDirective
 	Line   int
 }
 
@@ -25,12 +25,12 @@ func (h *HTTP) GetLine() int {
 }
 
 // SetParent change the parent block
-func (h *HTTP) SetParent(parent IBlock) {
+func (h *HTTP) SetParent(parent IDirective) {
 	h.Parent = parent
 }
 
 // GetParent the parent block
-func (h *HTTP) GetParent() IBlock {
+func (h *HTTP) GetParent() IDirective {
 	return h.Parent
 }
 

--- a/config/include.go
+++ b/config/include.go
@@ -9,7 +9,7 @@ type Include struct {
 	*Directive
 	IncludePath string
 	Configs     []*Config
-	Parent      IBlock
+	Parent      IDirective
 }
 
 //TODO(tufan): move that part into dumper package
@@ -38,12 +38,12 @@ func (c *Include) GetLine() int {
 }
 
 // GetParent the parent block
-func (c *Include) GetParent() IBlock {
+func (c *Include) GetParent() IDirective {
 	return c.Parent
 }
 
 // SetParent change the parent block
-func (c *Include) SetParent(parent IBlock) {
+func (c *Include) SetParent(parent IDirective) {
 	c.Parent = parent
 }
 

--- a/config/location.go
+++ b/config/location.go
@@ -7,7 +7,7 @@ type Location struct {
 	*Directive
 	Modifier string
 	Match    string
-	Parent   IBlock
+	Parent   IDirective
 	Line     int
 }
 
@@ -22,12 +22,12 @@ func (l *Location) GetLine() int {
 }
 
 // SetParent change the parent block
-func (l *Location) SetParent(parent IBlock) {
+func (l *Location) SetParent(parent IDirective) {
 	l.Parent = parent
 }
 
 // GetParent the parent block
-func (l *Location) GetParent() IBlock {
+func (l *Location) GetParent() IDirective {
 	return l.Parent
 }
 
@@ -55,4 +55,20 @@ func NewLocation(directive IDirective) (*Location, error) {
 		return location, nil
 	}
 	return nil, errors.New("too many arguments for location directive")
+}
+
+func (l *Location) FindDirectives(directiveName string) []IDirective {
+	block := l.GetBlock()
+	if block == nil {
+		return []IDirective{}
+	}
+	return block.FindDirectives(directiveName)
+}
+
+func (l *Location) GetDirectives() []IDirective {
+	block := l.GetBlock()
+	if block == nil {
+		return []IDirective{}
+	}
+	return block.GetDirectives()
 }

--- a/config/lua_block.go
+++ b/config/lua_block.go
@@ -11,7 +11,7 @@ type LuaBlock struct {
 	Comment    []string
 	DefaultInlineComment
 	LuaCode string
-	Parent  IBlock
+	Parent  IDirective
 	Line    int
 }
 
@@ -44,12 +44,12 @@ func (lb *LuaBlock) GetLine() int {
 }
 
 // SetParent change the parent block
-func (lb *LuaBlock) SetParent(parent IBlock) {
+func (lb *LuaBlock) SetParent(parent IDirective) {
 	lb.Parent = parent
 }
 
 // GetParent the parent block
-func (lb *LuaBlock) GetParent() IBlock {
+func (lb *LuaBlock) GetParent() IDirective {
 	return lb.Parent
 }
 

--- a/config/statement.go
+++ b/config/statement.go
@@ -5,8 +5,8 @@ type IBlock interface {
 	GetDirectives() []IDirective
 	FindDirectives(directiveName string) []IDirective
 	GetCodeBlock() string
-	SetParent(IBlock)
-	GetParent() IBlock
+	SetParent(IDirective)
+	GetParent() IDirective
 }
 
 // IDirective represents any directive
@@ -16,8 +16,8 @@ type IDirective interface {
 	GetBlock() IBlock
 	GetComment() []string
 	SetComment(comment []string)
-	SetParent(IBlock)
-	GetParent() IBlock
+	SetParent(IDirective)
+	GetParent() IDirective
 	GetLine() int
 	SetLine(int)
 	InlineCommenter

--- a/config/upstream.go
+++ b/config/upstream.go
@@ -12,7 +12,7 @@ type Upstream struct {
 	Directives []IDirective
 	Comment    []string
 	DefaultInlineComment
-	Parent IBlock
+	Parent IDirective
 	Line   int
 }
 
@@ -27,12 +27,12 @@ func (us *Upstream) GetLine() int {
 }
 
 // SetParent change the parent block
-func (us *Upstream) SetParent(parent IBlock) {
+func (us *Upstream) SetParent(parent IDirective) {
 	us.Parent = parent
 }
 
 // GetParent the parent block
-func (us *Upstream) GetParent() IBlock {
+func (us *Upstream) GetParent() IDirective {
 	return us.Parent
 }
 

--- a/config/upstream_server.go
+++ b/config/upstream_server.go
@@ -13,7 +13,7 @@ type UpstreamServer struct {
 	Parameters map[string]string
 	Comment    []string
 	DefaultInlineComment
-	Parent IBlock
+	Parent IDirective
 	Line   int
 }
 
@@ -28,12 +28,12 @@ func (uss *UpstreamServer) GetLine() int {
 }
 
 // SetParent change the parent block
-func (uss *UpstreamServer) SetParent(parent IBlock) {
+func (uss *UpstreamServer) SetParent(parent IDirective) {
 	uss.Parent = parent
 }
 
 // GetParent the parent block
-func (uss *UpstreamServer) GetParent() IBlock {
+func (uss *UpstreamServer) GetParent() IDirective {
 	return uss.Parent
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -219,7 +219,16 @@ parsingLoop:
 			if err != nil {
 				return nil, err
 			}
-			s.SetParent(context)
+			if s.GetBlock() == nil {
+				s.SetParent(s)
+			} else {
+				// each directive should have a parent directive, not a block
+				// find each directive in the block and set the parent directive
+				b := s.GetBlock()
+				for _, dir := range b.GetDirectives() {
+					dir.SetParent(s)
+				}
+			}
 			line = p.currentToken.Line
 			s.SetLine(line)
 			context.Directives = append(context.Directives, s)


### PR DESCRIPTION
### Fix Issue with `GetParent` Method

**Problem Description:**
I discovered that when obtaining a directive and attempting to retrieve its parent node more than twice, an error would occur. After investigation, I found that this issue arises because the `SetParent` method sets the parent as the block of the parent directive rather than the parent directive itself.

**Solution:**
To address this, I modified the `SetParent` and `GetParent` methods so that for each directive, its parent should be another directive rather than a block. This ensures that the parent-child relationship between directives is correctly maintained.

**Test Case:**
The following test case previously failed due to the issue but now runs successfully after the fix:

```go
p := NewStringParser(`user www www;
http {
	include mime.types;
	server {
		listen 80;
		location / {
			proxy_pass http://backend/;
		}
	}
}
`)
conf, err := p.Parse()
assert.NilError(t, err, "no error expected here")

listens := conf.FindDirectives("listen")
assert.Equal(t, len(listens), 1, "num of listen error")

serverIBlock := listens[0].GetParent()
server, ok := serverIBlock.(*config.Server)

assert.Equal(t, ok, true, "cannot convert listen parent to server")

_, ok = server.GetParent().(*config.HTTP)
assert.Equal(t, ok, true, "cannot convert server parent to http")