### PR TITLE
fix: QuotedString_ISSUE65

### DIFF
--- a/config/statement.go
+++ b/config/statement.go
@@ -25,23 +25,23 @@ type IDirective interface {
 
 // InlineCommenter represents the inline comment holder
 type InlineCommenter interface {
-	GetInlineComment() string
-	SetInlineComment(comment string)
+	GetInlineComment() []InlineComment
+	SetInlineComment(comment InlineComment)
 }
 
 // DefaultInlineComment represents the default inline comment holder
 type DefaultInlineComment struct {
-	InlineComment string
+	InlineComment []InlineComment
 }
 
 // GetInlineComment returns the inline comment
-func (d *DefaultInlineComment) GetInlineComment() string {
+func (d *DefaultInlineComment) GetInlineComment() []InlineComment {
 	return d.InlineComment
 }
 
 // SetInlineComment sets the inline comment
-func (d *DefaultInlineComment) SetInlineComment(comment string) {
-	d.InlineComment = comment
+func (d *DefaultInlineComment) SetInlineComment(comment InlineComment) {
+	d.InlineComment = append(d.InlineComment, comment)
 }
 
 // FileDirective a statement that saves its own file
@@ -84,3 +84,5 @@ func (p *Parameter) SetRelativeLineIndex(i int) {
 func (p *Parameter) GetRelativeLineIndex() int {
 	return p.RelativeLineIndex
 }
+
+type InlineComment Parameter

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -574,14 +574,14 @@ stream {
 
 func TestParser_KeepDataInMultiLine01(t *testing.T) {
 	p := NewStringParser(`log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-'$status $body_bytes_sent "$http_referer" '
-'"$http_user_agent" "$http_x_forwarded_for"';`)
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';`)
 	conf, err := p.Parse()
 	assert.NilError(t, err, "no error expected here")
 	s := dumper.DumpConfig(conf, dumper.IndentedStyle)
 	assert.Equal(t, `log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-'$status $body_bytes_sent "$http_referer" '
-'"$http_user_agent" "$http_x_forwarded_for"';`, s)
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';`, s)
 
 }
 
@@ -594,7 +594,25 @@ func TestParser_KeepDataInMultiLine02(t *testing.T) {
 	s := dumper.DumpConfig(conf, dumper.IndentedStyle)
 	assert.Equal(t, `events {
     worker_connections
-    4096;
+        4096;
 }`, s)
 
+}
+
+func TestParser_QuotedString_ISSUE65(t *testing.T) {
+	p := NewStringParser(`log_format json_analytics escape=json '{' # json start
+	'"msec": "$msec", ' # request unixtime in seconds with a milliseconds resolution
+    '"connection": "$connection", ' # connection serial number
+    '"connection_requests": "$connection_requests", ' # number of requests made in connection
+    '}'; # inline comment
+error_log off; # error_log inline comment`)
+	conf, err := p.Parse()
+	assert.NilError(t, err, "no error expected here")
+	s := dumper.DumpConfig(conf, dumper.IndentedStyle)
+	assert.Equal(t, `log_format json_analytics escape=json '{' # json start
+    '"msec": "$msec", ' # request unixtime in seconds with a milliseconds resolution
+    '"connection": "$connection", ' # connection serial number
+    '"connection_requests": "$connection_requests", ' # number of requests made in connection
+    '}';# inline comment
+error_log off;# error_log inline comment`, s)
 }


### PR DESCRIPTION
### Problem Analysis:
Comments can appear on any line, including within multi-line directives. The parser must correctly handle inline comments that appear within multi-line configurations.

### Fix:
Modified the `InLineComment` structure and logic to ensure that all functionalities of inline comments are properly handled. Specifically, this includes tracking the line numbers of inline comments so that they can be accurately output during configuration formatting.

This fix addresses the issue where the parser was failing to handle quoted strings followed by inline comments in multi-line directives, as described in issue #65.