### PR TITLE
Improve comments and add package docs

### DIFF
--- a/config/block.go
+++ b/config/block.go
@@ -1,6 +1,6 @@
 package config
 
-// Block a block statement
+// Block represents a block statement.
 type Block struct {
 	Directives  []IDirective
 	IsLuaBlock  bool
@@ -8,27 +8,27 @@ type Block struct {
 	Parent      IDirective
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (b *Block) SetParent(parent IDirective) {
 	b.Parent = parent
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (b *Block) GetParent() IDirective {
 	return b.Parent
 }
 
-// GetDirectives get all directives in this block
+// GetDirectives returns all directives in this block.
 func (b *Block) GetDirectives() []IDirective {
 	return b.Directives
 }
 
-// GetCodeBlock returns the literal code block
+// GetCodeBlock returns the literal code block.
 func (b *Block) GetCodeBlock() string {
 	return b.LiteralCode
 }
 
-// FindDirectives find directives in block recursively
+// FindDirectives finds directives in the block recursively.
 func (b *Block) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range b.GetDirectives() {

--- a/config/config.go
+++ b/config/config.go
@@ -1,12 +1,12 @@
 package config
 
-// Config  represents a whole config file.
+// Config represents a complete nginx configuration file.
 type Config struct {
 	*Block
 	FilePath string
 }
 
-// global warpper
+// Global wrappers provide extension points for custom directive handling.
 var (
 	BlockWrappers     = map[string]func(*Directive) (IDirective, error){}
 	DirectiveWrappers = map[string]func(*Directive) (IDirective, error){}

--- a/config/directive.go
+++ b/config/directive.go
@@ -1,6 +1,6 @@
 package config
 
-// Directive represents any nginx directive
+// Directive represents any nginx directive.
 type Directive struct {
 	Block      IBlock
 	Name       string
@@ -11,47 +11,47 @@ type Directive struct {
 	Line   int
 }
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (d *Directive) SetLine(line int) {
 	d.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (d *Directive) GetLine() int {
 	return d.Line
 }
 
-// SetParent  the parent block
+// SetParent sets the parent directive.
 func (d *Directive) SetParent(parent IDirective) {
 	d.Parent = parent
 }
 
-// GetParent change the parent block
+// GetParent returns the parent directive.
 func (d *Directive) GetParent() IDirective {
 	return d.Parent
 }
 
-// SetComment sets comment tied to this directive
+// SetComment sets the directive comment.
 func (d *Directive) SetComment(comment []string) {
 	d.Comment = comment
 }
 
-// GetName get directive name
+// GetName returns the directive name.
 func (d *Directive) GetName() string {
 	return d.Name
 }
 
-// GetParameters get all parameters of a directive
+// GetParameters returns all parameters of the directive.
 func (d *Directive) GetParameters() []Parameter {
 	return d.Parameters
 }
 
-// GetBlock get block if it has
+// GetBlock returns the directive block if it exists.
 func (d *Directive) GetBlock() IBlock {
 	return d.Block
 }
 
-// GetComment get directive comment
+// GetComment returns the directive comment.
 func (d *Directive) GetComment() []string {
 	return d.Comment
 }

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,2 @@
+// Package config models nginx directives and blocks.
+package config

--- a/config/http.go
+++ b/config/http.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// HTTP represents http block
+// HTTP represents an http block.
 type HTTP struct {
 	Servers    []*Server
 	Directives []IDirective
@@ -14,37 +14,37 @@ type HTTP struct {
 	Line   int
 }
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (h *HTTP) SetLine(line int) {
 	h.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (h *HTTP) GetLine() int {
 	return h.Line
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (h *HTTP) SetParent(parent IDirective) {
 	h.Parent = parent
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (h *HTTP) GetParent() IDirective {
 	return h.Parent
 }
 
-// GetComment comment of the HTTP directive
+// GetComment returns the comment of the HTTP directive.
 func (h *HTTP) GetComment() []string {
 	return h.Comment
 }
 
-// SetComment set the comment of the HTTP directive
+// SetComment sets the comment of the HTTP directive.
 func (h *HTTP) SetComment(comment []string) {
 	h.Comment = comment
 }
 
-// NewHTTP create an http block from a directive which has a block
+// NewHTTP creates an HTTP block from a directive that has a block.
 func NewHTTP(directive IDirective) (*HTTP, error) {
 	if block := directive.GetBlock(); block != nil {
 		http := &HTTP{
@@ -67,17 +67,17 @@ func NewHTTP(directive IDirective) (*HTTP, error) {
 	return nil, errors.New("http directive must have a block")
 }
 
-// GetName get directive name to construct the statment string
+// GetName returns the directive name to construct the statement string.
 func (h *HTTP) GetName() string { //the directive name.
 	return "http"
 }
 
-// GetParameters get directive parameters if any
+// GetParameters returns directive parameters, if any.
 func (h *HTTP) GetParameters() []Parameter {
 	return []Parameter{}
 }
 
-// GetDirectives get all directives in http
+// GetDirectives returns all directives in the http block.
 func (h *HTTP) GetDirectives() []IDirective {
 	directives := make([]IDirective, 0)
 	directives = append(directives, h.Directives...)
@@ -87,7 +87,7 @@ func (h *HTTP) GetDirectives() []IDirective {
 	return directives
 }
 
-// FindDirectives find directives
+// FindDirectives finds directives in the http block.
 func (h *HTTP) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range h.GetDirectives() {
@@ -107,12 +107,12 @@ func (h *HTTP) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
-// GetBlock get block if any
+// GetBlock returns the block itself.
 func (h *HTTP) GetBlock() IBlock {
 	return h
 }
 
-// GetCodeBlock returns the literal code block
+// GetCodeBlock returns the literal code block.
 func (h *HTTP) GetCodeBlock() string {
 	return ""
 }

--- a/config/include.go
+++ b/config/include.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// Include include structure
+// Include represents an include directive.
 type Include struct {
 	*Directive
 	IncludePath string
@@ -27,27 +27,27 @@ type Include struct {
 //	return nil
 //}
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (c *Include) SetLine(line int) {
 	c.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (c *Include) GetLine() int {
 	return c.Line
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (c *Include) GetParent() IDirective {
 	return c.Parent
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (c *Include) SetParent(parent IDirective) {
 	c.Parent = parent
 }
 
-// GetDirectives return all directives inside the included file
+// GetDirectives returns all directives inside the included file.
 func (c *Include) GetDirectives() []IDirective {
 	directives := make([]IDirective, 0)
 	for _, config := range c.Configs {
@@ -57,7 +57,7 @@ func (c *Include) GetDirectives() []IDirective {
 	return directives
 }
 
-// FindDirectives find a specific directive in included file
+// FindDirectives finds a specific directive in the included file.
 func (c *Include) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, config := range c.Configs {
@@ -67,17 +67,17 @@ func (c *Include) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
-// GetName get directive name
+// GetName returns the directive name.
 func (c *Include) GetName() string {
 	return c.Directive.Name
 }
 
-// SetComment set comment of include directive
+// SetComment sets the comment of the include directive.
 func (c *Include) SetComment(comment []string) {
 	c.Comment = comment
 }
 
-// NewInclude initialize an include block from a directive
+// NewInclude initializes an Include from a directive.
 func NewInclude(dir IDirective) (*Include, error) {
 	directive, ok := dir.(*Directive)
 	if !ok {

--- a/config/location.go
+++ b/config/location.go
@@ -2,7 +2,7 @@ package config
 
 import "errors"
 
-// Location represents a location in nginx config
+// Location represents a location block in an nginx configuration.
 type Location struct {
 	*Directive
 	Modifier string
@@ -11,27 +11,27 @@ type Location struct {
 	Line     int
 }
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (l *Location) SetLine(line int) {
 	l.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (l *Location) GetLine() int {
 	return l.Line
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (l *Location) SetParent(parent IDirective) {
 	l.Parent = parent
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (l *Location) GetParent() IDirective {
 	return l.Parent
 }
 
-// NewLocation initialize a location block from a directive
+// NewLocation initializes a Location from a directive.
 func NewLocation(directive IDirective) (*Location, error) {
 	dir, ok := directive.(*Directive)
 	if !ok {
@@ -57,7 +57,7 @@ func NewLocation(directive IDirective) (*Location, error) {
 	return nil, errors.New("too many arguments for location directive")
 }
 
-// FindDirectives find directives by name
+// FindDirectives finds directives by name.
 func (l *Location) FindDirectives(directiveName string) []IDirective {
 	block := l.GetBlock()
 	if block == nil {
@@ -66,7 +66,7 @@ func (l *Location) FindDirectives(directiveName string) []IDirective {
 	return block.FindDirectives(directiveName)
 }
 
-// GetDirectives get all directives
+// GetDirectives returns all directives in the location block.
 func (l *Location) GetDirectives() []IDirective {
 	block := l.GetBlock()
 	if block == nil {

--- a/config/server.go
+++ b/config/server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// Server represents server block
+// Server represents a server block.
 type Server struct {
 	Block   IBlock
 	Comment []string
@@ -13,37 +13,37 @@ type Server struct {
 	Line   int
 }
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (s *Server) SetLine(line int) {
 	s.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (s *Server) GetLine() int {
 	return s.Line
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (s *Server) SetParent(parent IDirective) {
 	s.Parent = parent
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (s *Server) GetParent() IDirective {
 	return s.Parent
 }
 
-// SetComment set comment of server directive
+// SetComment sets the comment of the server directive.
 func (s *Server) SetComment(comment []string) {
 	s.Comment = comment
 }
 
-// GetComment get comment of server directive
+// GetComment returns the comment of the server directive.
 func (s *Server) GetComment() []string {
 	return s.Comment
 }
 
-// NewServer create a server block from a directive with block
+// NewServer creates a server block from a directive with a block.
 func NewServer(directive IDirective) (*Server, error) {
 	if block := directive.GetBlock(); block != nil {
 		return &Server{
@@ -55,22 +55,22 @@ func NewServer(directive IDirective) (*Server, error) {
 	return nil, errors.New("server directive must have a block")
 }
 
-// GetName get directive name to construct the statment string
+// GetName returns the directive name to construct the statement string.
 func (s *Server) GetName() string { //the directive name.
 	return "server"
 }
 
-// GetParameters get directive parameters if any
+// GetParameters returns directive parameters if any.
 func (s *Server) GetParameters() []Parameter {
 	return []Parameter{}
 }
 
-// GetBlock get block if any
+// GetBlock returns the block if any.
 func (s *Server) GetBlock() IBlock {
 	return s.Block
 }
 
-// FindDirectives find directives
+// FindDirectives finds directives within the server block.
 func (s *Server) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range s.GetDirectives() {
@@ -90,7 +90,7 @@ func (s *Server) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
-// GetDirectives get all directives in Server
+// GetDirectives returns all directives in the server.
 func (s *Server) GetDirectives() []IDirective {
 	block := s.GetBlock()
 	if block == nil {

--- a/config/upstream.go
+++ b/config/upstream.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// Upstream represents `upstream{}` block
+// Upstream represents an `upstream{}` block.
 type Upstream struct {
 	UpstreamName    string
 	UpstreamServers []*UpstreamServer
@@ -16,52 +16,52 @@ type Upstream struct {
 	Line   int
 }
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (us *Upstream) SetLine(line int) {
 	us.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (us *Upstream) GetLine() int {
 	return us.Line
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (us *Upstream) SetParent(parent IDirective) {
 	us.Parent = parent
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (us *Upstream) GetParent() IDirective {
 	return us.Parent
 }
 
-// SetComment set comment of the directive
+// SetComment sets the directive comment.
 func (us *Upstream) SetComment(comment []string) {
 	us.Comment = comment
 }
 
-// GetName Statement interface
+// GetName implements the Statement interface.
 func (us *Upstream) GetName() string {
 	return "upstream"
 }
 
-// GetParameters upsrema parameters
+// GetParameters returns the upstream parameters.
 func (us *Upstream) GetParameters() []Parameter {
 	return []Parameter{{Value: us.UpstreamName}} //the only parameter for an upstream is its name
 }
 
-// GetBlock upstream does not have block
+// GetBlock returns the upstream itself, which implements IBlock.
 func (us *Upstream) GetBlock() IBlock {
 	return us
 }
 
-// GetComment get directive comment
+// GetComment returns the directive comment.
 func (us *Upstream) GetComment() []string {
 	return us.Comment
 }
 
-// GetDirectives get sub directives of upstream
+// GetDirectives returns sub directives of the upstream.
 func (us *Upstream) GetDirectives() []IDirective {
 	directives := make([]IDirective, 0)
 	directives = append(directives, us.Directives...)
@@ -72,7 +72,7 @@ func (us *Upstream) GetDirectives() []IDirective {
 	return directives
 }
 
-// NewUpstream creaste new upstream from a directive
+// NewUpstream creates a new Upstream from a directive.
 func NewUpstream(directive IDirective) (*Upstream, error) {
 	parameters := directive.GetParameters()
 	us := &Upstream{
@@ -105,17 +105,17 @@ func NewUpstream(directive IDirective) (*Upstream, error) {
 	return us, nil
 }
 
-// AddServer add a server to upstream
+// AddServer adds a server to the upstream.
 func (us *Upstream) AddServer(server *UpstreamServer) {
 	us.UpstreamServers = append(us.UpstreamServers, server)
 }
 
-// GetCodeBlock returns the literal code block
+// GetCodeBlock returns the literal code block.
 func (us *Upstream) GetCodeBlock() string {
 	return ""
 }
 
-// FindDirectives find directives in block recursively
+// FindDirectives finds directives in the block recursively.
 func (us *Upstream) FindDirectives(directiveName string) []IDirective {
 	directives := make([]IDirective, 0)
 	for _, directive := range us.Directives {

--- a/config/upstream_server.go
+++ b/config/upstream_server.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// UpstreamServer represents `server` directive in `upstream{}` block
+// UpstreamServer represents a `server` directive in an `upstream{}` block.
 type UpstreamServer struct {
 	Address    string
 	Flags      []string
@@ -17,52 +17,52 @@ type UpstreamServer struct {
 	Line   int
 }
 
-// SetLine Set line number
+// SetLine sets the line number.
 func (uss *UpstreamServer) SetLine(line int) {
 	uss.Line = line
 }
 
-// GetLine Get the line number
+// GetLine returns the line number.
 func (uss *UpstreamServer) GetLine() int {
 	return uss.Line
 }
 
-// SetParent change the parent block
+// SetParent sets the parent directive.
 func (uss *UpstreamServer) SetParent(parent IDirective) {
 	uss.Parent = parent
 }
 
-// GetParent the parent block
+// GetParent returns the parent directive.
 func (uss *UpstreamServer) GetParent() IDirective {
 	return uss.Parent
 }
 
-// SetComment set comment of the directive
+// SetComment sets the directive comment.
 func (uss *UpstreamServer) SetComment(comment []string) {
 	uss.Comment = comment
 }
 
-// GetComment get comment of the directive
+// GetComment returns the directive comment.
 func (uss *UpstreamServer) GetComment() []string {
 	return uss.Comment
 }
 
-// GetName return directive name, Statement  interface
+// GetName implements the Statement interface.
 func (uss *UpstreamServer) GetName() string {
 	return "server"
 }
 
-// GetBlock block of an upstream, basically nil
+// GetBlock returns nil because upstream servers do not have blocks.
 func (uss *UpstreamServer) GetBlock() IBlock {
 	return nil
 }
 
-// GetParameters block of an upstream, basically nil
+// GetParameters returns parameters for the upstream server.
 func (uss *UpstreamServer) GetParameters() []Parameter {
 	return uss.GetDirective().Parameters
 }
 
-// GetDirective get directive of the upstreamserver
+// GetDirective returns the directive representation of the upstream server.
 func (uss *UpstreamServer) GetDirective() *Directive {
 	//First, generate a new directive from upstream server
 	directive := &Directive{
@@ -98,7 +98,7 @@ func (uss *UpstreamServer) GetDirective() *Directive {
 	return directive
 }
 
-// NewUpstreamServer creates an upstream server from a directive
+// NewUpstreamServer creates an UpstreamServer from a directive.
 func NewUpstreamServer(directive IDirective) (*UpstreamServer, error) {
 	uss := &UpstreamServer{
 		Flags:      make([]string, 0),

--- a/dumper/doc.go
+++ b/dumper/doc.go
@@ -1,0 +1,2 @@
+// Package dumper renders configuration structures back into nginx config text.
+package dumper

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -1,0 +1,2 @@
+// Package parser parses nginx configuration files into structured objects.
+package parser


### PR DESCRIPTION
## Summary
- refine exported function comments across config package
- add package documentation files for config, parser and dumper

## Testing
- `bash -c 'go test -race -cover ${PWD}/{config,dumper,parser,parser/token}'`

------
https://chatgpt.com/codex/tasks/task_e_6855219e1d248329a34ecf1f3719b756