### PR TITLE
Implement server helper API for lookup/listen/location management

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -238,6 +238,47 @@ func main() {
 }
 ```
 
+### Query and update server listen/location data
+```go
+func main() {
+	p := parser.NewStringParser(`http{
+	server{
+		listen 80;
+		server_name example.com www.example.com;
+		location /api {
+			proxy_pass http://127.0.0.1:5000;
+		}
+	}
+}`)
+
+	conf, err := p.Parse()
+	if err != nil {
+		panic(err)
+	}
+
+	httpBlocks := conf.FindDirectives("http")
+	http, ok := httpBlocks[0].(*config.HTTP)
+	if !ok {
+		panic("http directive type mismatch")
+	}
+
+	server := http.GetServerByServerName("example.com")
+	if server == nil {
+		panic("server not found")
+	}
+
+	ports := server.GetListenPorts() // []int{80}
+	fmt.Println(ports)
+
+	if err := server.SetListenPort(0, 8080); err != nil {
+		panic(err)
+	}
+
+	locations := server.GetLocations()
+	fmt.Println(len(locations))
+}
+```
+
 ### Update directive
 
 ```go
@@ -550,6 +591,7 @@ type HTTP struct {
 }
 ```
 + ```func (h *HTTP) FindDirectives(directiveName string) []IDirective```
++ ```func (h *HTTP) GetServerByServerName(serverName string) *Server```
 
 #### Server (impl IDirective)
 ```go
@@ -560,6 +602,9 @@ type Server struct {
 }
 ```
 + ```func (s *Server) AddLocation(location *Location)```
++ ```func (s *Server) GetLocations() []*Location```
++ ```func (s *Server) GetListenPorts() []int```
++ ```func (s *Server) SetListenPort(index int, port int) error```
 ---
 ### Dumper
 Dumper is the package that holds styling configuration only. 

--- a/config/http.go
+++ b/config/http.go
@@ -107,6 +107,23 @@ func (h *HTTP) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
+// GetServerByServerName returns the first server that contains the given server_name.
+func (h *HTTP) GetServerByServerName(serverName string) *Server {
+	for _, server := range h.Servers {
+		if server == nil {
+			continue
+		}
+		for _, directive := range server.FindDirectives("server_name") {
+			for _, parameter := range directive.GetParameters() {
+				if parameter.GetValue() == serverName {
+					return server
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // GetBlock returns the block itself.
 func (h *HTTP) GetBlock() IBlock {
 	return h

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -1,0 +1,46 @@
+package config
+
+import "testing"
+
+func TestHTTP_GetServerByServerName(t *testing.T) {
+	t.Parallel()
+
+	serverA := &Server{
+		Block: &Block{
+			Directives: []IDirective{
+				&Directive{
+					Name:       "server_name",
+					Parameters: []Parameter{{Value: "example.com"}, {Value: "www.example.com"}},
+				},
+			},
+		},
+	}
+	serverB := &Server{
+		Block: &Block{
+			Directives: []IDirective{
+				&Directive{
+					Name:       "server_name",
+					Parameters: []Parameter{{Value: "api.example.com"}},
+				},
+			},
+		},
+	}
+	http := &HTTP{
+		Servers: []*Server{serverA, serverB},
+	}
+
+	got := http.GetServerByServerName("www.example.com")
+	if got != serverA {
+		t.Fatalf("expected serverA, got %v", got)
+	}
+
+	got = http.GetServerByServerName("api.example.com")
+	if got != serverB {
+		t.Fatalf("expected serverB, got %v", got)
+	}
+
+	got = http.GetServerByServerName("missing.example.com")
+	if got != nil {
+		t.Fatalf("expected nil for missing server name, got %v", got)
+	}
+}

--- a/config/server.go
+++ b/config/server.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 // Server represents a server block.
@@ -97,6 +100,142 @@ func (s *Server) GetDirectives() []IDirective {
 		return []IDirective{}
 	}
 	return block.GetDirectives()
+}
+
+// GetLocations returns direct child location blocks in the server.
+func (s *Server) GetLocations() []*Location {
+	locations := make([]*Location, 0)
+	for _, directive := range s.GetDirectives() {
+		location, ok := directive.(*Location)
+		if !ok {
+			continue
+		}
+		locations = append(locations, location)
+	}
+	return locations
+}
+
+// GetListenPorts returns listen ports from direct child listen directives.
+// Non-port listen endpoints (for example unix sockets) are ignored.
+func (s *Server) GetListenPorts() []int {
+	ports := make([]int, 0)
+	for _, listen := range s.getListenDirectives() {
+		if len(listen.Parameters) == 0 {
+			continue
+		}
+		port, ok := parseListenPortValue(listen.Parameters[0].GetValue())
+		if !ok {
+			continue
+		}
+		ports = append(ports, port)
+	}
+	return ports
+}
+
+// SetListenPort updates the port of the listen directive at the given index.
+func (s *Server) SetListenPort(index int, port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid listen port: %d", port)
+	}
+
+	listens := s.getListenDirectives()
+	if index < 0 || index >= len(listens) {
+		return fmt.Errorf("listen index out of range: %d", index)
+	}
+
+	listen := listens[index]
+	if len(listen.Parameters) == 0 {
+		listen.Parameters = append(listen.Parameters, Parameter{Value: strconv.Itoa(port)})
+		return nil
+	}
+
+	updated, err := formatListenEndpointWithPort(listen.Parameters[0].GetValue(), port)
+	if err != nil {
+		return err
+	}
+	listen.Parameters[0].SetValue(updated)
+	return nil
+}
+
+func (s *Server) getListenDirectives() []*Directive {
+	listens := make([]*Directive, 0)
+	for _, directive := range s.GetDirectives() {
+		listen, ok := directive.(*Directive)
+		if !ok {
+			continue
+		}
+		if listen.GetName() != "listen" {
+			continue
+		}
+		listens = append(listens, listen)
+	}
+	return listens
+}
+
+func parseListenPortValue(value string) (int, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.HasPrefix(value, "unix:") {
+		return 0, false
+	}
+	if isDecimal(value) {
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			return 0, false
+		}
+		return port, true
+	}
+	if strings.HasPrefix(value, "[") {
+		sep := strings.LastIndex(value, "]:")
+		if sep > 0 && isDecimal(value[sep+2:]) {
+			port, err := strconv.Atoi(value[sep+2:])
+			if err != nil {
+				return 0, false
+			}
+			return port, true
+		}
+	}
+	sep := strings.LastIndex(value, ":")
+	if sep > 0 && isDecimal(value[sep+1:]) {
+		port, err := strconv.Atoi(value[sep+1:])
+		if err != nil {
+			return 0, false
+		}
+		return port, true
+	}
+	return 0, false
+}
+
+func formatListenEndpointWithPort(value string, port int) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || isDecimal(value) {
+		return strconv.Itoa(port), nil
+	}
+	if strings.HasPrefix(value, "unix:") {
+		return "", fmt.Errorf("cannot set port on unix socket listen %q", value)
+	}
+	if strings.HasPrefix(value, "[") {
+		sep := strings.LastIndex(value, "]:")
+		if sep > 0 && isDecimal(value[sep+2:]) {
+			return value[:sep+2] + strconv.Itoa(port), nil
+		}
+	}
+	sep := strings.LastIndex(value, ":")
+	if sep > 0 && isDecimal(value[sep+1:]) {
+		return value[:sep+1] + strconv.Itoa(port), nil
+	}
+	return "", fmt.Errorf("unsupported listen value %q", value)
+}
+
+func isDecimal(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // AddLocation appends a location block to the server.

--- a/config/server_test.go
+++ b/config/server_test.go
@@ -94,3 +94,128 @@ func TestServer_AddLocation_InitializesServerBlock(t *testing.T) {
 		t.Fatal("location parent should be server")
 	}
 }
+
+func TestServer_GetLocations_DirectChildrenOnly(t *testing.T) {
+	t.Parallel()
+
+	directLocation := &Location{
+		Directive: &Directive{
+			Name:       "location",
+			Parameters: []Parameter{{Value: "/api"}},
+			Block:      &Block{},
+		},
+		Match: "/api",
+	}
+
+	indirectLocation := &Location{
+		Directive: &Directive{
+			Name:       "location",
+			Parameters: []Parameter{{Value: "/nested"}},
+			Block:      &Block{},
+		},
+		Match: "/nested",
+	}
+
+	s := &Server{
+		Block: &Block{
+			Directives: []IDirective{
+				&Directive{
+					Name: "if",
+					Block: &Block{
+						Directives: []IDirective{indirectLocation},
+					},
+				},
+				directLocation,
+			},
+		},
+	}
+
+	locations := s.GetLocations()
+	if len(locations) != 1 {
+		t.Fatalf("expected 1 direct location, got %d", len(locations))
+	}
+	if locations[0] != directLocation {
+		t.Fatal("unexpected location returned")
+	}
+}
+
+func TestServer_GetListenPorts(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		Block: &Block{
+			Directives: []IDirective{
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "80"}}},
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "127.0.0.1:8080"}}},
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "[::]:443"}}},
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "unix:/tmp/nginx.sock"}}},
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "localhost:notaport"}}},
+			},
+		},
+	}
+
+	ports := s.GetListenPorts()
+	if len(ports) != 3 {
+		t.Fatalf("expected 3 listen ports, got %d", len(ports))
+	}
+	if ports[0] != 80 || ports[1] != 8080 || ports[2] != 443 {
+		t.Fatalf("unexpected listen ports: %#v", ports)
+	}
+}
+
+func TestServer_SetListenPort(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		Block: &Block{
+			Directives: []IDirective{
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "80"}}},
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "127.0.0.1:8080"}, {Value: "ssl"}}},
+				&Directive{Name: "listen", Parameters: []Parameter{}},
+			},
+		},
+	}
+
+	if err := s.SetListenPort(0, 8081); err != nil {
+		t.Fatalf("SetListenPort(0) unexpected error: %v", err)
+	}
+	if got := s.GetDirectives()[0].GetParameters()[0].GetValue(); got != "8081" {
+		t.Fatalf("expected updated first listen to 8081, got %q", got)
+	}
+
+	if err := s.SetListenPort(1, 8443); err != nil {
+		t.Fatalf("SetListenPort(1) unexpected error: %v", err)
+	}
+	if got := s.GetDirectives()[1].GetParameters()[0].GetValue(); got != "127.0.0.1:8443" {
+		t.Fatalf("expected updated host:port listen, got %q", got)
+	}
+
+	if err := s.SetListenPort(2, 9090); err != nil {
+		t.Fatalf("SetListenPort(2) unexpected error: %v", err)
+	}
+	if got := s.GetDirectives()[2].GetParameters()[0].GetValue(); got != "9090" {
+		t.Fatalf("expected inserted listen parameter 9090, got %q", got)
+	}
+}
+
+func TestServer_SetListenPort_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		Block: &Block{
+			Directives: []IDirective{
+				&Directive{Name: "listen", Parameters: []Parameter{{Value: "unix:/tmp/nginx.sock"}}},
+			},
+		},
+	}
+
+	if err := s.SetListenPort(1, 8080); err == nil {
+		t.Fatal("expected index out of range error")
+	}
+	if err := s.SetListenPort(0, 0); err == nil {
+		t.Fatal("expected invalid port error")
+	}
+	if err := s.SetListenPort(0, 8080); err == nil {
+		t.Fatal("expected unix socket error")
+	}
+}


### PR DESCRIPTION
## Final API Decision (owner-level)
This issue requested a richer server API. To keep it practical and backward-compatible, this PR implements a **method-based first step** instead of introducing a new `Listen` model right now.

Implemented:
- `(*config.HTTP).GetServerByServerName(serverName string) *Server`
- `(*config.Server).GetLocations() []*Location` (direct child locations only)
- `(*config.Server).GetListenPorts() []int` (numeric TCP ports only)
- `(*config.Server).SetListenPort(index int, port int) error`

Behavior decisions:
- `GetServerByServerName` returns the **first matching** server (or `nil`)
- `GetListenPorts` ignores non-port listen endpoints (for example `unix:/...`)
- `SetListenPort` preserves listen endpoint form when possible (`80`, `127.0.0.1:8080`, `[::]:443`)

## Tests
- Added `config/http_test.go`
- Extended `config/server_test.go` with listen/location helper coverage
- Ran `go test ./config`
- Ran `make test`

Closes #47
